### PR TITLE
Add hover functionality to menu options

### DIFF
--- a/include/States/MenuState.h
+++ b/include/States/MenuState.h
@@ -81,6 +81,7 @@ namespace FishGame
         // State
         MenuOption m_selectedOption;
         MenuOption m_previousOption;
+        std::optional<MenuOption> m_hoveredOption;
 
         // Animation data
         float m_animationTime;


### PR DESCRIPTION
- Introduced `m_hoveredOption` to track the currently hovered menu item.
- Initialized `m_hoveredOption` in the constructor and reset it during navigation.
- Updated logic to set `m_hoveredOption` based on mouse position.
- Enhanced rendering to apply a pulsing effect to the hovered option.
- Updated texture rendering for the hovered option for better visual feedback.
- Ensured `m_hoveredOption` is reset when the menu state becomes active.