### PR TITLE
Refactor: remove unused code

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -44,9 +44,7 @@ namespace FishGame
         void addPoints(int points);
         void resetSize();
         void fullReset();
-        int getCurrentStage() const { return m_currentStage; }
         int getScore() const { return m_score; }
-        float getGrowthProgress() const { return m_growthProgress; }
 
         void enableMouseControl(bool enable);
         void setMousePosition(const sf::Vector2f& screenPos);
@@ -85,9 +83,6 @@ namespace FishGame
         void setWindowBounds(const sf::Vector2u& windowSize);
 
         // Statistics tracking
-        int getTotalFishEaten() const { return m_totalFishEaten; }
-        int getDamageTaken() const { return m_damageTaken; }
-        bool hasTakenDamage() const { return m_damageTaken > 0; }
 
         // Visual effects
         void triggerEatEffect();

--- a/include/Systems/ScoreSystem.h
+++ b/include/Systems/ScoreSystem.h
@@ -71,9 +71,7 @@ namespace FishGame
 
         // Score tracking
         int getCurrentScore() const { return m_currentScore; }
-        int getTotalScore() const { return m_totalScore; }
         void setCurrentScore(int score) { m_currentScore = score; }
-        void addToTotalScore(int score) { m_totalScore += score; }
         void reset();
 
     private:
@@ -84,7 +82,6 @@ namespace FishGame
 
         // Score tracking
         int m_currentScore;
-        int m_totalScore;
 
         // Chain system
         int m_currentChain;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -988,7 +988,6 @@ namespace FishGame
     {
         m_gameState.currentLevel++;
         m_gameState.totalScore += m_scoreSystem->getCurrentScore();
-        m_scoreSystem->addToTotalScore(m_scoreSystem->getCurrentScore());
 
         if (m_gameState.currentLevel % 3 == 0)
         {

--- a/src/Systems/ScoreSystem.cpp
+++ b/src/Systems/ScoreSystem.cpp
@@ -88,7 +88,6 @@ namespace FishGame
     ScoreSystem::ScoreSystem(const sf::Font& font)
         : m_font(font)
         , m_currentScore(0)
-        , m_totalScore(0)
         , m_currentChain(0)
         , m_floatingScores()
     {


### PR DESCRIPTION
## Summary
- drop unused total score tracking from `ScoreSystem`
- remove unused accessors from `Player`
- clean up level advancement code

## Testing
- `cmake --preset x64-Debug` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685430d3103483339659568f3efcd9ef