### PR TITLE
Refactor bonus items and powerups to sprite graphics

### DIFF
--- a/include/Entities/BonusItem.h
+++ b/include/Entities/BonusItem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Entity.h"
+#include "SpriteComponent.h"
 #include <random>
 
 namespace FishGame
@@ -70,13 +71,10 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        sf::CircleShape m_shape;
-        std::vector<sf::ConvexShape> m_arms;
         float m_rotation;
 
         static constexpr int m_starfishPoints = 25;
         static constexpr float m_rotationSpeed = 30.0f;
-        static constexpr int m_armCount = 5;
     };
 
     // Pearl Oyster - opens periodically with white/black pearls
@@ -95,16 +93,17 @@ namespace FishGame
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         void updateOpenState(sf::Time deltaTime);
+        void initializeSprite(SpriteManager& spriteManager);
 
     protected:
-        // Changed from private to protected for derived class access
-        sf::ConvexShape m_topShell;
-        sf::ConvexShape m_bottomShell;
-        sf::CircleShape m_pearl;
+        sf::Sprite m_pearlSprite;
+        const sf::Texture* m_openTexture{nullptr};
+        const sf::Texture* m_closedTexture{nullptr};
+        const sf::Texture* m_whitePearlTexture{nullptr};
+        const sf::Texture* m_blackPearlTexture{nullptr};
 
         bool m_isOpen;
         bool m_hasBlackPearl;
-        float m_openAngle;
 
         sf::Time m_stateTimer;
         sf::Time m_openDuration;

--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -16,14 +16,12 @@ namespace FishGame
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Cyan; }
 
-        void setFont(const sf::Font& font) { m_icon.setFont(font); }
+        void setFont(const sf::Font& font) {}
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        sf::Text m_icon;
-        std::vector<sf::RectangleShape> m_iceShards;
         static constexpr float m_freezeDuration = Constants::FREEZE_POWERUP_DURATION;
     };
 
@@ -42,7 +40,6 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        sf::CircleShape m_heart;
         float m_heartbeatAnimation;
         static constexpr float m_heartbeatSpeed = Constants::EXTRA_LIFE_HEARTBEAT_SPEED;
     };
@@ -62,7 +59,6 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        std::vector<sf::ConvexShape> m_speedLines;
         float m_lineAnimation;
         static constexpr float m_boostDuration = Constants::SPEEDBOOST_POWERUP_DURATION;
         static constexpr float m_speedMultiplier = Constants::SPEED_BOOST_MULTIPLIER;

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "BonusItem.h"
-#include <vector>
-#include <algorithm>
+#include "SpriteComponent.h"
 
 namespace FishGame
 {
@@ -34,9 +33,6 @@ namespace FishGame
         PowerUpType m_powerUpType;
         sf::Time m_duration;
 
-        // Shared visual components
-        sf::CircleShape m_iconBackground;
-        sf::CircleShape m_aura;
         float m_pulseAnimation;
     };
 
@@ -51,13 +47,10 @@ namespace FishGame
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Yellow; }
 
-        void setFont(const sf::Font& font) { m_icon.setFont(font); }
+        void setFont(const sf::Font& font) {}
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
-
-    private:
-        sf::Text m_icon; // "2X" text
     };
 
     // Frenzy Starter - instantly activates Frenzy Mode
@@ -75,7 +68,6 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        std::vector<sf::CircleShape> m_lightningBolts;
         float m_sparkAnimation;
     };
 

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -1,6 +1,5 @@
 #include "BonusItem.h"
 #include "GameConstants.h"
-#include "DrawHelpers.h"
 #include "SpriteManager.h"
 #include <cmath>
 #include <algorithm>
@@ -54,42 +53,9 @@ namespace FishGame
     // Starfish implementation
     Starfish::Starfish()
         : BonusItem(BonusType::Starfish, m_starfishPoints)
-        , m_shape(20.0f, 5)
-        , m_arms()
         , m_rotation(0.0f)
     {
         m_radius = 20.0f;
-
-        // Setup main shape
-        m_shape.setFillColor(sf::Color(255, 192, 203)); // Pink
-        m_shape.setOutlineColor(sf::Color(220, 150, 170));
-        m_shape.setOutlineThickness(2.0f);
-        m_shape.setOrigin(m_radius, m_radius);
-
-        // Create star arms using convex shapes
-        m_arms.reserve(m_armCount);
-        std::generate_n(std::back_inserter(m_arms), m_armCount,
-            [this, i = 0]() mutable {
-                sf::ConvexShape arm(4);
-                float angle = (360.0f / m_armCount) * i;
-                float radAngle = angle * Constants::DEG_TO_RAD;
-
-                // Create arm points
-                arm.setPoint(0, sf::Vector2f(0, 0));
-                arm.setPoint(1, sf::Vector2f(std::cos(radAngle - 0.2f) * 10.0f,
-                    std::sin(radAngle - 0.2f) * 10.0f));
-                arm.setPoint(2, sf::Vector2f(std::cos(radAngle) * 18.0f,
-                    std::sin(radAngle) * 18.0f));
-                arm.setPoint(3, sf::Vector2f(std::cos(radAngle + 0.2f) * 10.0f,
-                    std::sin(radAngle + 0.2f) * 10.0f));
-
-                arm.setFillColor(sf::Color(255, 182, 193));
-                arm.setOutlineColor(sf::Color(220, 150, 170));
-                arm.setOutlineThickness(1.0f);
-
-                ++i;
-                return arm;
-            });
     }
 
     void Starfish::initializeSprite(SpriteManager& spriteManager)
@@ -105,32 +71,45 @@ namespace FishGame
         }
     }
 
+    void PearlOyster::initializeSprite(SpriteManager& spriteManager)
+    {
+        auto sprite = spriteManager.createSpriteComponent(
+            static_cast<Entity*>(this), TextureID::PearlOysterClosed);
+        if (sprite)
+        {
+            auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PearlOysterClosed);
+            sprite->configure(config);
+            setSpriteComponent(std::move(sprite));
+            setRenderMode(RenderMode::Sprite);
+
+            m_openTexture = &spriteManager.getTexture(TextureID::PearlOysterOpen);
+            m_closedTexture = &spriteManager.getTexture(TextureID::PearlOysterClosed);
+            m_whitePearlTexture = &spriteManager.getTexture(TextureID::WhitePearl);
+            m_blackPearlTexture = &spriteManager.getTexture(TextureID::BlackPearl);
+
+            m_pearlSprite.setTexture(*m_whitePearlTexture);
+            m_pearlSprite.setOrigin(m_pearlSprite.getLocalBounds().width / 2.f,
+                                    m_pearlSprite.getLocalBounds().height / 2.f);
+        }
+    }
+
     void Starfish::update(sf::Time deltaTime)
     {
         if (!updateLifetime(deltaTime))
             return;
 
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
-        {
-            getSpriteComponent()->update(deltaTime);
-        }
-
         // Rotation animation
         m_rotation += m_rotationSpeed * deltaTime.asSeconds();
+
+        if (getSpriteComponent())
+        {
+            getSpriteComponent()->update(deltaTime);
+            getSpriteComponent()->setRotation(m_rotation);
+        }
 
         // Bobbing animation
         m_position.y = m_baseY + computeBobbingOffset();
 
-        // Update visual positions
-        m_shape.setPosition(m_position);
-        m_shape.setRotation(m_rotation);
-
-        // Update arms
-        std::for_each(m_arms.begin(), m_arms.end(),
-            [this](sf::ConvexShape& arm) {
-                arm.setPosition(m_position);
-                arm.setRotation(m_rotation);
-            });
     }
 
     void Starfish::onCollect()
@@ -141,29 +120,15 @@ namespace FishGame
 
     void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
-        {
+        if (getSpriteComponent())
             target.draw(*getSpriteComponent(), states);
-        }
-        else
-        {
-            // Draw arms first
-            DrawUtils::drawContainer(m_arms, target, states);
-
-            // Draw center
-            target.draw(m_shape, states);
-        }
     }
 
     // PearlOyster implementation
     PearlOyster::PearlOyster()
         : BonusItem(BonusType::PearlOyster, 0)
-        , m_topShell(4)
-        , m_bottomShell(4)
-        , m_pearl(5.0f)
         , m_isOpen(false)
         , m_hasBlackPearl(false)
-        , m_openAngle(0.0f)
         , m_stateTimer(sf::Time::Zero)
         , m_openDuration(sf::seconds(2.0f))
         , m_closedDuration(sf::seconds(3.0f))
@@ -185,30 +150,6 @@ namespace FishGame
             m_hasBlackPearl = true;
             m_points = m_blackPearlPoints;
         }
-        // Setup shells
-        // Top shell (trapezoid shape)
-        m_topShell.setPoint(0, sf::Vector2f(-20, 0));
-        m_topShell.setPoint(1, sf::Vector2f(20, 0));
-        m_topShell.setPoint(2, sf::Vector2f(15, -25));
-        m_topShell.setPoint(3, sf::Vector2f(-15, -25));
-        m_topShell.setFillColor(sf::Color(169, 169, 169)); // Gray
-        m_topShell.setOutlineColor(sf::Color(105, 105, 105));
-        m_topShell.setOutlineThickness(2.0f);
-
-        // Bottom shell
-        m_bottomShell.setPoint(0, sf::Vector2f(-20, 0));
-        m_bottomShell.setPoint(1, sf::Vector2f(20, 0));
-        m_bottomShell.setPoint(2, sf::Vector2f(15, 25));
-        m_bottomShell.setPoint(3, sf::Vector2f(-15, 25));
-        m_bottomShell.setFillColor(sf::Color(169, 169, 169));
-        m_bottomShell.setOutlineColor(sf::Color(105, 105, 105));
-        m_bottomShell.setOutlineThickness(2.0f);
-
-        // Setup pearl
-        m_pearl.setFillColor(m_hasBlackPearl ? sf::Color(50, 50, 50) : sf::Color(250, 250, 250));
-        m_pearl.setOutlineColor(m_hasBlackPearl ? sf::Color::Black : sf::Color(200, 200, 200));
-        m_pearl.setOutlineThickness(1.0f);
-        m_pearl.setOrigin(5.0f, 5.0f);
     }
 
     void PearlOyster::update(sf::Time deltaTime)
@@ -219,17 +160,22 @@ namespace FishGame
         // Update open/close state
         updateOpenState(deltaTime);
 
+        if (getSpriteComponent())
+            getSpriteComponent()->update(deltaTime);
+
         // Bobbing animation
         m_position.y = m_baseY + computeBobbingOffset(0.5f, 0.5f);
 
-        // Update positions
-        m_topShell.setPosition(m_position);
-        m_bottomShell.setPosition(m_position);
-        m_pearl.setPosition(m_position);
-
-        // Apply opening animation
-        m_topShell.setRotation(-m_openAngle);
-        m_bottomShell.setRotation(m_openAngle);
+        m_pearlSprite.setPosition(m_position);
+        if (m_isOpen)
+        {
+            getSpriteComponent()->getSprite().setTexture(*m_openTexture);
+            m_pearlSprite.setTexture(m_hasBlackPearl ? *m_blackPearlTexture : *m_whitePearlTexture);
+        }
+        else
+        {
+            getSpriteComponent()->getSprite().setTexture(*m_closedTexture);
+        }
     }
 
     void PearlOyster::onCollect()
@@ -243,14 +189,11 @@ namespace FishGame
 
     void PearlOyster::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_bottomShell, states);
+        if (getSpriteComponent())
+            target.draw(*getSpriteComponent(), states);
 
-        if (m_isOpen && m_points > 0)
-        {
-            target.draw(m_pearl, states);
-        }
-
-        target.draw(m_topShell, states);
+        if (m_isOpen)
+            target.draw(m_pearlSprite, states);
     }
 
     void PearlOyster::updateOpenState(sf::Time deltaTime)
@@ -259,13 +202,6 @@ namespace FishGame
 
         if (m_isOpen)
         {
-            // Opening animation
-            if (m_openAngle < m_maxOpenAngle)
-            {
-                m_openAngle = std::min(m_openAngle + 180.0f * deltaTime.asSeconds(), m_maxOpenAngle);
-            }
-
-            // Check if should close
             if (m_stateTimer >= m_openDuration)
             {
                 m_isOpen = false;
@@ -274,13 +210,6 @@ namespace FishGame
         }
         else
         {
-            // Closing animation
-            if (m_openAngle > 0.0f)
-            {
-                m_openAngle = std::max(m_openAngle - 300.0f * deltaTime.asSeconds(), 0.0f);
-            }
-
-            // Check if should open
             if (m_stateTimer >= m_closedDuration)
             {
                 m_isOpen = true;

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -2,34 +2,13 @@
 #include <algorithm>
 #include <cmath>
 #include <iterator>
-#include "Utils/DrawHelpers.h"
 
 namespace FishGame
 {
     // FreezePowerUp implementation
     FreezePowerUp::FreezePowerUp()
         : PowerUp(PowerUpType::Freeze, sf::seconds(m_freezeDuration))
-        , m_icon()
-        , m_iceShards()
     {
-        m_icon.setString("*");
-        m_icon.setCharacterSize(32);
-        m_icon.setFillColor(sf::Color::Cyan);
-
-        sf::FloatRect bounds = m_icon.getLocalBounds();
-        m_icon.setOrigin(bounds.width / 2.0f, bounds.height / 2.0f);
-
-        // Create ice shard effects
-        m_iceShards.reserve(6);
-        std::generate_n(std::back_inserter(m_iceShards), 6, []
-            {
-                sf::RectangleShape shard(sf::Vector2f(3.0f, 15.0f));
-                shard.setFillColor(sf::Color(200, 240, 255));
-                shard.setOrigin(1.5f, 7.5f);
-                return shard;
-            });
-
-        m_aura.setOutlineColor(getAuraColor());
     }
 
     void FreezePowerUp::update(sf::Time deltaTime)
@@ -38,38 +17,10 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        // Update animations
         m_pulseAnimation += deltaTime.asSeconds() * 2.0f;
-        float pulse = 1.0f + 0.2f * std::sin(m_pulseAnimation);
-
-        // Bobbing animation
         m_position.y = m_baseY + computeBobbingOffset();
-
-        // Update visual positions
-        m_iconBackground.setPosition(m_position);
-        m_iconBackground.setScale(pulse, pulse);
-        m_aura.setPosition(m_position);
-        m_icon.setPosition(m_position);
-
-        // Update ice shards
-        for (size_t i = 0; i < m_iceShards.size(); ++i)
-        {
-            float angle = (60.0f * i + m_pulseAnimation * 30.0f) * Constants::DEG_TO_RAD;
-            float radius = 20.0f + 5.0f * std::sin(m_pulseAnimation);
-
-            sf::Vector2f shardPos(
-                m_position.x + std::cos(angle) * radius,
-                m_position.y + std::sin(angle) * radius
-            );
-
-            m_iceShards[i].setPosition(shardPos);
-            m_iceShards[i].setRotation(angle * Constants::RAD_TO_DEG);
-        }
-
-        // Update aura glow
-        sf::Color auraColor = getAuraColor();
-        auraColor.a = static_cast<sf::Uint8>(128 + 127 * std::sin(m_pulseAnimation * 0.5f));
-        m_aura.setOutlineColor(auraColor);
+        if (getSpriteComponent())
+            getSpriteComponent()->update(deltaTime);
     }
 
     void FreezePowerUp::onCollect()
@@ -79,26 +30,15 @@ namespace FishGame
 
     void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
-
-        DrawUtils::drawContainer(m_iceShards, target, states);
-
-        target.draw(m_icon, states);
+        if (getSpriteComponent())
+            target.draw(*getSpriteComponent(), states);
     }
 
     // ExtraLifePowerUp implementation
     ExtraLifePowerUp::ExtraLifePowerUp()
         : PowerUp(PowerUpType::ExtraLife, sf::Time::Zero)
-        , m_heart(10.0f, 8)
         , m_heartbeatAnimation(0.0f)
     {
-        m_heart.setFillColor(sf::Color(255, 100, 100));
-        m_heart.setOutlineColor(sf::Color(200, 50, 50));
-        m_heart.setOutlineThickness(2.0f);
-        m_heart.setOrigin(10.0f, 10.0f);
-
-        m_aura.setOutlineColor(getAuraColor());
     }
 
     void ExtraLifePowerUp::update(sf::Time deltaTime)
@@ -107,24 +47,15 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        // Update animations
         m_heartbeatAnimation += deltaTime.asSeconds() * m_heartbeatSpeed;
-        float heartbeat = 1.0f + 0.2f * std::sin(m_heartbeatAnimation);
         m_pulseAnimation += deltaTime.asSeconds() * 3.0f;
-
-        // Bobbing animation
         m_position.y = m_baseY + computeBobbingOffset();
-
-        // Update positions
-        m_iconBackground.setPosition(m_position);
-        m_aura.setPosition(m_position);
-        m_heart.setPosition(m_position);
-        m_heart.setScale(heartbeat, heartbeat);
-
-        // Update aura
-        sf::Color auraColor = getAuraColor();
-        auraColor.a = static_cast<sf::Uint8>(128 + 127 * std::sin(m_pulseAnimation * 0.5f));
-        m_aura.setOutlineColor(auraColor);
+        if (getSpriteComponent())
+        {
+            getSpriteComponent()->update(deltaTime);
+            float scale = 1.0f + 0.2f * std::sin(m_heartbeatAnimation);
+            getSpriteComponent()->setScale(scale, scale);
+        }
     }
 
     void ExtraLifePowerUp::onCollect()
@@ -134,31 +65,15 @@ namespace FishGame
 
     void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
-        target.draw(m_heart, states);
+        if (getSpriteComponent())
+            target.draw(*getSpriteComponent(), states);
     }
 
     // SpeedBoostPowerUp implementation
     SpeedBoostPowerUp::SpeedBoostPowerUp()
         : PowerUp(PowerUpType::SpeedBoost, sf::seconds(m_boostDuration))
-        , m_speedLines()
         , m_lineAnimation(0.0f)
     {
-        // Create speed line effects
-        m_speedLines.reserve(4);
-        std::generate_n(std::back_inserter(m_speedLines), 4, []
-            {
-                sf::ConvexShape line(4);
-                line.setPoint(0, sf::Vector2f(0, -2));
-                line.setPoint(1, sf::Vector2f(15, -1));
-                line.setPoint(2, sf::Vector2f(15, 1));
-                line.setPoint(3, sf::Vector2f(0, 2));
-                line.setFillColor(sf::Color(0, 255, 255, 150));
-                return line;
-            });
-
-        m_aura.setOutlineColor(getAuraColor());
     }
 
     void SpeedBoostPowerUp::update(sf::Time deltaTime)
@@ -167,38 +82,11 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        // Update animations
         m_lineAnimation += deltaTime.asSeconds() * 5.0f;
         m_pulseAnimation += deltaTime.asSeconds() * 4.0f;
-        float pulse = 1.0f + 0.15f * std::sin(m_pulseAnimation);
-
-        // Bobbing animation
         m_position.y = m_baseY + computeBobbingOffset(1.5f);
-
-        // Update positions
-        m_iconBackground.setPosition(m_position);
-        m_iconBackground.setScale(pulse, pulse);
-        m_aura.setPosition(m_position);
-
-        // Update speed lines
-        for (size_t i = 0; i < m_speedLines.size(); ++i)
-        {
-            float angle = (90.0f * i) * Constants::DEG_TO_RAD;
-            float offset = 10.0f + 10.0f * std::sin(m_lineAnimation + i);
-
-            sf::Vector2f linePos(
-                m_position.x + std::cos(angle) * offset,
-                m_position.y + std::sin(angle) * offset
-            );
-
-            m_speedLines[i].setPosition(linePos);
-            m_speedLines[i].setRotation(angle * Constants::RAD_TO_DEG);
-        }
-
-        // Update aura
-        sf::Color auraColor = getAuraColor();
-        auraColor.a = static_cast<sf::Uint8>(128 + 127 * std::sin(m_pulseAnimation * 0.5f));
-        m_aura.setOutlineColor(auraColor);
+        if (getSpriteComponent())
+            getSpriteComponent()->update(deltaTime);
     }
 
     void SpeedBoostPowerUp::onCollect()
@@ -208,9 +96,7 @@ namespace FishGame
 
     void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
-
-        DrawUtils::drawContainer(m_speedLines, target, states);
+        if (getSpriteComponent())
+            target.draw(*getSpriteComponent(), states);
     }
 }

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -1,9 +1,7 @@
 #include "PowerUp.h"
 #include "GameConstants.h"
-#include "Utils/DrawHelpers.h"
 #include <cmath>
 #include <algorithm>
-#include <iterator>
 
 namespace FishGame
 {
@@ -12,22 +10,11 @@ namespace FishGame
         : BonusItem(BonusType::PowerUp, 0)
         , m_powerUpType(type)
         , m_duration(duration)
-        , m_iconBackground(25.0f)
-        , m_aura(35.0f)
         , m_pulseAnimation(0.0f)
     {
         m_radius = 25.0f;
         m_lifetime = sf::seconds(15.0f);
 
-        // Setup visual components
-        m_iconBackground.setOrigin(25.0f, 25.0f);
-        m_iconBackground.setFillColor(sf::Color(50, 50, 50, 200));
-        m_iconBackground.setOutlineColor(sf::Color::White);
-        m_iconBackground.setOutlineThickness(2.0f);
-
-        m_aura.setOrigin(35.0f, 35.0f);
-        m_aura.setFillColor(sf::Color::Transparent);
-        m_aura.setOutlineThickness(3.0f);
     }
 
     // Do NOT implement update() here - let derived classes handle it
@@ -36,20 +23,7 @@ namespace FishGame
     ScoreDoublerPowerUp::ScoreDoublerPowerUp()
         : PowerUp(PowerUpType::ScoreDoubler,
             sf::seconds(Constants::SCORE_DOUBLER_POWERUP_DURATION))
-        , m_icon()
     {
-        // Setup "2X" icon text - font will be set later
-        m_icon.setString("2X");
-        m_icon.setCharacterSize(24);
-        m_icon.setStyle(sf::Text::Bold);
-        m_icon.setFillColor(sf::Color::Yellow);
-
-        // Center the text
-        sf::FloatRect bounds = m_icon.getLocalBounds();
-        m_icon.setOrigin(bounds.width / 2.0f, bounds.height / 2.0f);
-
-        // Set aura color
-        m_aura.setOutlineColor(getAuraColor());
     }
 
     void ScoreDoublerPowerUp::update(sf::Time deltaTime)
@@ -57,27 +31,10 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        // Pulse animation
         m_pulseAnimation += deltaTime.asSeconds() * 3.0f;
-        float pulse = 1.0f + 0.2f * std::sin(m_pulseAnimation);
-
-        // Bobbing
         m_position.y = m_baseY + computeBobbingOffset();
-
-        // Update positions
-        m_iconBackground.setPosition(m_position);
-        m_iconBackground.setScale(pulse, pulse);
-
-        m_aura.setPosition(m_position);
-        m_aura.setScale(pulse * 1.1f, pulse * 1.1f);
-
-        m_icon.setPosition(m_position);
-        m_icon.setScale(pulse, pulse);
-
-        // Aura glow effect
-        sf::Color auraColor = getAuraColor();
-        auraColor.a = static_cast<sf::Uint8>(128 + 127 * std::sin(m_pulseAnimation * 0.5f));
-        m_aura.setOutlineColor(auraColor);
+        if (getSpriteComponent())
+            getSpriteComponent()->update(deltaTime);
     }
 
     void ScoreDoublerPowerUp::onCollect()
@@ -87,28 +44,15 @@ namespace FishGame
 
     void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
-        target.draw(m_icon, states);
+        if (getSpriteComponent())
+            target.draw(*getSpriteComponent(), states);
     }
 
     // FrenzyStarterPowerUp implementation
     FrenzyStarterPowerUp::FrenzyStarterPowerUp()
         : PowerUp(PowerUpType::FrenzyStarter, sf::Time::Zero)
-        , m_lightningBolts()
         , m_sparkAnimation(0.0f)
     {
-        // Create lightning bolt shapes
-        m_lightningBolts.reserve(4);
-        std::generate_n(std::back_inserter(m_lightningBolts), 4, [] {
-            sf::CircleShape bolt(3.0f, 3);
-            bolt.setFillColor(sf::Color::Magenta);
-            bolt.setOrigin(3.0f, 3.0f);
-            return bolt;
-            });
-
-        // Set aura color
-        m_aura.setOutlineColor(getAuraColor());
     }
 
     void FrenzyStarterPowerUp::update(sf::Time deltaTime)
@@ -116,40 +60,11 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        // Animation updates
         m_pulseAnimation += deltaTime.asSeconds() * 4.0f;
         m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
-
-        float pulse = 1.0f + 0.3f * std::sin(m_pulseAnimation);
-
-        // Bobbing with faster frequency
         m_position.y = m_baseY + computeBobbingOffset(2.0f);
-
-        // Update positions
-        m_iconBackground.setPosition(m_position);
-        m_iconBackground.setScale(pulse, pulse);
-
-        m_aura.setPosition(m_position);
-        m_aura.setScale(pulse * 1.2f, pulse * 1.2f);
-
-        // Update lightning bolts - rotate around center
-        for (size_t i = 0; i < m_lightningBolts.size(); ++i)
-        {
-            float angle = m_sparkAnimation + (i * 90.0f);
-            float radius = 15.0f + 5.0f * std::sin(m_sparkAnimation * 2.0f);
-
-            sf::Vector2f boltPos;
-            boltPos.x = m_position.x + std::cos(angle * Constants::DEG_TO_RAD) * radius;
-            boltPos.y = m_position.y + std::sin(angle * Constants::DEG_TO_RAD) * radius;
-
-            m_lightningBolts[i].setPosition(boltPos);
-            m_lightningBolts[i].setRotation(angle);
-        }
-
-        // Electric aura effect
-        sf::Color auraColor = getAuraColor();
-        auraColor.a = static_cast<sf::Uint8>(100 + 155 * std::abs(std::sin(m_sparkAnimation)));
-        m_aura.setOutlineColor(auraColor);
+        if (getSpriteComponent())
+            getSpriteComponent()->update(deltaTime);
     }
 
     void FrenzyStarterPowerUp::onCollect()
@@ -159,11 +74,8 @@ namespace FishGame
 
     void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
-
-        // Draw lightning bolts
-        DrawUtils::drawContainer(m_lightningBolts, target, states);
+        if (getSpriteComponent())
+            target.draw(*getSpriteComponent(), states);
     }
 
     // PowerUpManager implementation


### PR DESCRIPTION
## Summary
- switch Starfish and PearlOyster to sprites
- remove geometric shapes from bonus items and powerups
- simplify extra powerups update/draw logic

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685434e8c4748333bdaafd6d501f651b