### PR TITLE
Fix texture update on oyster sprite

### DIFF
--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -169,12 +169,14 @@ namespace FishGame
         m_pearlSprite.setPosition(m_position);
         if (m_isOpen)
         {
-            getSpriteComponent()->getSprite().setTexture(*m_openTexture);
+            // swap to the open oyster texture and update the pearl color
+            getSpriteComponent()->setTexture(*m_openTexture);
             m_pearlSprite.setTexture(m_hasBlackPearl ? *m_blackPearlTexture : *m_whitePearlTexture);
         }
         else
         {
-            getSpriteComponent()->getSprite().setTexture(*m_closedTexture);
+            // revert to the closed oyster texture
+            getSpriteComponent()->setTexture(*m_closedTexture);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure PearlOyster uses SpriteComponent::setTexture instead of modifying the internal sprite directly

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68543896ea1c83339be625cb82f8b94d