### PR TITLE
Refactor drawing helpers and bonus collection

### DIFF
--- a/include/Entities/BonusItem.h
+++ b/include/Entities/BonusItem.h
@@ -29,7 +29,7 @@ namespace FishGame
         // Bonus item interface
         virtual BonusType getBonusType() const { return m_bonusType; }
         virtual int getPoints() const { return m_points; }
-        virtual void onCollect() = 0;
+        virtual void onCollect();
 
         // Lifetime management
         void setLifetime(sf::Time lifetime) { m_lifetime = lifetime; }
@@ -65,7 +65,6 @@ namespace FishGame
         void initializeSprite(SpriteManager& spriteManager);
 
         void update(sf::Time deltaTime) override;
-        void onCollect() override;
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;

--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -13,7 +13,6 @@ namespace FishGame
         ~FreezePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Cyan; }
 
         void setFont(const sf::Font& font) {}
@@ -33,7 +32,6 @@ namespace FishGame
         ~ExtraLifePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Green; }
 
     protected:
@@ -52,7 +50,6 @@ namespace FishGame
         ~SpeedBoostPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color(0, 255, 255); }
 
     protected:

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -44,7 +44,6 @@ namespace FishGame
         ~ScoreDoublerPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Yellow; }
 
         void setFont(const sf::Font& font) {}
@@ -61,7 +60,6 @@ namespace FishGame
         ~FrenzyStarterPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Magenta; }
 
     protected:

--- a/include/Utils/DrawHelpers.h
+++ b/include/Utils/DrawHelpers.h
@@ -13,4 +13,14 @@ namespace FishGame::DrawUtils {
                 target.draw(drawable, states);
             });
     }
+
+    // Draw an entity's sprite component if one exists
+    template<typename EntityType>
+    void drawSpriteIfPresent(const EntityType& entity, sf::RenderTarget& target,
+        sf::RenderStates states = {})
+    {
+        if (auto sprite = entity.getSpriteComponent())
+            target.draw(*sprite, states);
+    }
 }
+

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -1,6 +1,7 @@
 #include "BonusItem.h"
 #include "GameConstants.h"
 #include "SpriteManager.h"
+#include "Utils/DrawHelpers.h"
 #include <cmath>
 #include <algorithm>
 #include <iterator>
@@ -44,11 +45,16 @@ namespace FishGame
         return true;
     }
 
-    float BonusItem::computeBobbingOffset(float freqMul, float ampMul) const
-    {
-        return std::sin(m_lifetimeElapsed.asSeconds() * m_bobFrequency * freqMul) *
-            m_bobAmplitude * ampMul;
-    }
+float BonusItem::computeBobbingOffset(float freqMul, float ampMul) const
+{
+    return std::sin(m_lifetimeElapsed.asSeconds() * m_bobFrequency * freqMul) *
+        m_bobAmplitude * ampMul;
+}
+
+void BonusItem::onCollect()
+{
+    destroy();
+}
 
     // Starfish implementation
     Starfish::Starfish()
@@ -112,16 +118,9 @@ namespace FishGame
 
     }
 
-    void Starfish::onCollect()
-    {
-        // Visual/audio feedback would go here
-        destroy();
-    }
-
     void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
     }
 
     // PearlOyster implementation
@@ -191,8 +190,7 @@ namespace FishGame
 
     void PearlOyster::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
 
         if (m_isOpen)
             target.draw(m_pearlSprite, states);

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -1,4 +1,5 @@
 #include "ExtendedPowerUps.h"
+#include "Utils/DrawHelpers.h"
 #include <algorithm>
 #include <cmath>
 #include <iterator>
@@ -23,15 +24,9 @@ namespace FishGame
             getSpriteComponent()->update(deltaTime);
     }
 
-    void FreezePowerUp::onCollect()
-    {
-        destroy();
-    }
-
     void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
     }
 
     // ExtraLifePowerUp implementation
@@ -58,15 +53,9 @@ namespace FishGame
         }
     }
 
-    void ExtraLifePowerUp::onCollect()
-    {
-        destroy();
-    }
-
     void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
     }
 
     // SpeedBoostPowerUp implementation
@@ -89,14 +78,8 @@ namespace FishGame
             getSpriteComponent()->update(deltaTime);
     }
 
-    void SpeedBoostPowerUp::onCollect()
-    {
-        destroy();
-    }
-
     void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
     }
 }

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -2,6 +2,7 @@
 #include "Player.h"
 #include "GameConstants.h"
 #include "SpriteManager.h"
+#include "Utils/DrawHelpers.h"
 #include <cmath>
 #include <numeric>
 #include <algorithm>
@@ -279,8 +280,8 @@ namespace FishGame
     void Jellyfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
         if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
-    {
-            target.draw(*getSpriteComponent(), states);
+        {
+            DrawUtils::drawSpriteIfPresent(*this, target, states);
         }
         else
         {

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -1,5 +1,6 @@
 #include "PowerUp.h"
 #include "GameConstants.h"
+#include "Utils/DrawHelpers.h"
 #include <cmath>
 #include <algorithm>
 
@@ -37,15 +38,9 @@ namespace FishGame
             getSpriteComponent()->update(deltaTime);
     }
 
-    void ScoreDoublerPowerUp::onCollect()
-    {
-        destroy();
-    }
-
     void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
     }
 
     // FrenzyStarterPowerUp implementation
@@ -67,15 +62,9 @@ namespace FishGame
             getSpriteComponent()->update(deltaTime);
     }
 
-    void FrenzyStarterPowerUp::onCollect()
-    {
-        destroy();
-    }
-
     void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
-            target.draw(*getSpriteComponent(), states);
+        DrawUtils::drawSpriteIfPresent(*this, target, states);
     }
 
     // PowerUpManager implementation


### PR DESCRIPTION
## Summary
- centralize sprite drawing logic in `DrawUtils::drawSpriteIfPresent`
- give `BonusItem` a default `onCollect` implementation
- remove duplicate `onCollect` overrides
- use new helper in several entity classes

## Testing
- `cmake -B build -S .` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685446665a40833380eeca9e5440be00