### PR TITLE
Refactor common entity and power‑up code

### DIFF
--- a/include/Entities/Entity.h
+++ b/include/Entities/Entity.h
@@ -138,5 +138,13 @@ namespace FishGame
                 entities.end()
             );
         }
+
+        // Utility to create a bounding rectangle for a circular entity
+        inline sf::FloatRect makeBounds(const sf::Vector2f& position,
+            float radius) noexcept
+        {
+            return { position.x - radius, position.y - radius,
+                radius * 2.f, radius * 2.f };
+        }
     }
 }

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -34,6 +34,10 @@ namespace FishGame
         sf::Time m_duration;
 
         float m_pulseAnimation;
+
+        // Common update logic shared by many power-ups
+        void commonUpdate(sf::Time deltaTime, float pulseSpeed,
+            float freqMul = 1.f, float ampMul = 1.f);
     };
 
     // Score Doubler - doubles all points for duration

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -25,11 +25,10 @@ namespace FishGame
     {
     }
 
-    sf::FloatRect BonusItem::getBounds() const
-    {
-        return sf::FloatRect(m_position.x - m_radius, m_position.y - m_radius,
-            m_radius * 2.0f, m_radius * 2.0f);
-    }
+sf::FloatRect BonusItem::getBounds() const
+{
+    return EntityUtils::makeBounds(m_position, m_radius);
+}
 
     bool BonusItem::updateLifetime(sf::Time deltaTime)
     {

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -12,17 +12,10 @@ namespace FishGame
     {
     }
 
-    void FreezePowerUp::update(sf::Time deltaTime)
-    {
-        // DO NOT call base class update - implement everything here
-        if (!updateLifetime(deltaTime))
-            return;
-
-        m_pulseAnimation += deltaTime.asSeconds() * 2.0f;
-        m_position.y = m_baseY + computeBobbingOffset();
-        if (getSpriteComponent())
-            getSpriteComponent()->update(deltaTime);
-    }
+void FreezePowerUp::update(sf::Time deltaTime)
+{
+    commonUpdate(deltaTime, 2.0f);
+}
 
     void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -36,22 +29,16 @@ namespace FishGame
     {
     }
 
-    void ExtraLifePowerUp::update(sf::Time deltaTime)
+void ExtraLifePowerUp::update(sf::Time deltaTime)
+{
+    commonUpdate(deltaTime, 3.0f);
+    m_heartbeatAnimation += deltaTime.asSeconds() * m_heartbeatSpeed;
+    if (auto sprite = getSpriteComponent())
     {
-        // DO NOT call base class update - implement everything here
-        if (!updateLifetime(deltaTime))
-            return;
-
-        m_heartbeatAnimation += deltaTime.asSeconds() * m_heartbeatSpeed;
-        m_pulseAnimation += deltaTime.asSeconds() * 3.0f;
-        m_position.y = m_baseY + computeBobbingOffset();
-        if (getSpriteComponent())
-        {
-            getSpriteComponent()->update(deltaTime);
-            float scale = 1.0f + 0.2f * std::sin(m_heartbeatAnimation);
-            getSpriteComponent()->setScale(scale, scale);
-        }
+        float scale = 1.0f + 0.2f * std::sin(m_heartbeatAnimation);
+        sprite->setScale(scale, scale);
     }
+}
 
     void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -65,18 +52,11 @@ namespace FishGame
     {
     }
 
-    void SpeedBoostPowerUp::update(sf::Time deltaTime)
-    {
-        // DO NOT call base class update - implement everything here
-        if (!updateLifetime(deltaTime))
-            return;
-
-        m_lineAnimation += deltaTime.asSeconds() * 5.0f;
-        m_pulseAnimation += deltaTime.asSeconds() * 4.0f;
-        m_position.y = m_baseY + computeBobbingOffset(1.5f);
-        if (getSpriteComponent())
-            getSpriteComponent()->update(deltaTime);
-    }
+void SpeedBoostPowerUp::update(sf::Time deltaTime)
+{
+    commonUpdate(deltaTime, 4.0f, 1.5f);
+    m_lineAnimation += deltaTime.asSeconds() * 5.0f;
+}
 
     void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -294,11 +294,10 @@ namespace FishGame
         }
     }
 
-    sf::FloatRect Fish::getBounds() const
-    {
-        return sf::FloatRect(m_position.x - m_radius, m_position.y - m_radius,
-            m_radius * 2.0f, m_radius * 2.0f);
-    }
+sf::FloatRect Fish::getBounds() const
+{
+    return EntityUtils::makeBounds(m_position, m_radius);
+}
 
     void Fish::setDirection(float dirX, float dirY)
     {

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -98,12 +98,11 @@ namespace FishGame
         }
     }
 
-    sf::FloatRect Bomb::getBounds() const
-    {
-        float effectiveRadius = m_isExploding ? m_explosionRadius : m_radius;
-        return sf::FloatRect(m_position.x - effectiveRadius, m_position.y - effectiveRadius,
-            effectiveRadius * 2.0f, effectiveRadius * 2.0f);
-    }
+sf::FloatRect Bomb::getBounds() const
+{
+    float effectiveRadius = m_isExploding ? m_explosionRadius : m_radius;
+    return EntityUtils::makeBounds(m_position, effectiveRadius);
+}
 
     void Bomb::onContact(Entity& entity)
     {
@@ -262,13 +261,12 @@ namespace FishGame
         }
     }
 
-    sf::FloatRect Jellyfish::getBounds() const
-    {
-        // Include tentacle reach
-        float effectiveRadius = m_radius + 15.0f;
-        return sf::FloatRect(m_position.x - effectiveRadius, m_position.y - effectiveRadius,
-            effectiveRadius * 2.0f, effectiveRadius * 2.0f);
-    }
+sf::FloatRect Jellyfish::getBounds() const
+{
+    // Include tentacle reach
+    float effectiveRadius = m_radius + 15.0f;
+    return EntityUtils::makeBounds(m_position, effectiveRadius);
+}
 
     void Jellyfish::onContact(Entity& entity)
     {

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -276,11 +276,10 @@ namespace FishGame
         m_targetPosition = mousePosition;
     }
 
-    sf::FloatRect Player::getBounds() const
-    {
-        return sf::FloatRect(m_position.x - m_radius, m_position.y - m_radius,
-            m_radius * 2.0f, m_radius * 2.0f);
-    }
+sf::FloatRect Player::getBounds() const
+{
+    return EntityUtils::makeBounds(m_position, m_radius);
+}
 
     void Player::grow(int scoreValue)
     {

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -18,6 +18,19 @@ namespace FishGame
 
     }
 
+    void PowerUp::commonUpdate(sf::Time deltaTime, float pulseSpeed,
+        float freqMul, float ampMul)
+    {
+        if (!updateLifetime(deltaTime))
+            return;
+
+        m_pulseAnimation += deltaTime.asSeconds() * pulseSpeed;
+        m_position.y = m_baseY + computeBobbingOffset(freqMul, ampMul);
+
+        if (auto sprite = getSpriteComponent())
+            sprite->update(deltaTime);
+    }
+
     // Do NOT implement update() here - let derived classes handle it
 
     // ScoreDoublerPowerUp implementation
@@ -27,16 +40,10 @@ namespace FishGame
     {
     }
 
-    void ScoreDoublerPowerUp::update(sf::Time deltaTime)
-    {
-        if (!updateLifetime(deltaTime))
-            return;
-
-        m_pulseAnimation += deltaTime.asSeconds() * 3.0f;
-        m_position.y = m_baseY + computeBobbingOffset();
-        if (getSpriteComponent())
-            getSpriteComponent()->update(deltaTime);
-    }
+void ScoreDoublerPowerUp::update(sf::Time deltaTime)
+{
+    commonUpdate(deltaTime, 3.0f);
+}
 
     void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -50,17 +57,11 @@ namespace FishGame
     {
     }
 
-    void FrenzyStarterPowerUp::update(sf::Time deltaTime)
-    {
-        if (!updateLifetime(deltaTime))
-            return;
-
-        m_pulseAnimation += deltaTime.asSeconds() * 4.0f;
-        m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
-        m_position.y = m_baseY + computeBobbingOffset(2.0f);
-        if (getSpriteComponent())
-            getSpriteComponent()->update(deltaTime);
-    }
+void FrenzyStarterPowerUp::update(sf::Time deltaTime)
+{
+    commonUpdate(deltaTime, 4.0f, 2.0f);
+    m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
+}
 
     void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {


### PR DESCRIPTION
## Summary
- add `EntityUtils::makeBounds` to remove repeated bounding box logic
- consolidate power-up updates through new `PowerUp::commonUpdate`
- update all affected entities to use the helpers

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68544db823e88333849b1d73cbc63a83