### PR TITLE
Refactor drawing and spawn utilities

### DIFF
--- a/include/Entities/BonusItem.h
+++ b/include/Entities/BonusItem.h
@@ -2,6 +2,7 @@
 
 #include "Entity.h"
 #include "SpriteComponent.h"
+#include "Utils/SpriteDrawable.h"
 #include <random>
 
 namespace FishGame
@@ -55,7 +56,7 @@ namespace FishGame
     };
 
     // Starfish bonus item - fixed points
-    class Starfish : public BonusItem
+    class Starfish : public BonusItem, public SpriteDrawable<Starfish>
     {
     public:
         Starfish();
@@ -65,9 +66,6 @@ namespace FishGame
         void initializeSprite(SpriteManager& spriteManager);
 
         void update(sf::Time deltaTime) override;
-
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
         float m_rotation;

--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -2,11 +2,12 @@
 
 #include "PowerUp.h"
 #include "GameConstants.h"
+#include "Utils/SpriteDrawable.h"
 
 namespace FishGame
 {
     // Freeze Power-up - freezes all enemy fish temporarily
-    class FreezePowerUp : public PowerUp
+    class FreezePowerUp : public PowerUp, public SpriteDrawable<FreezePowerUp>
     {
     public:
         FreezePowerUp();
@@ -17,15 +18,12 @@ namespace FishGame
 
         void setFont(const sf::Font& font) {}
 
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
-
     private:
         static constexpr float m_freezeDuration = Constants::FREEZE_POWERUP_DURATION;
     };
 
     // Extra Life Power-up - grants an additional life
-    class ExtraLifePowerUp : public PowerUp
+    class ExtraLifePowerUp : public PowerUp, public SpriteDrawable<ExtraLifePowerUp>
     {
     public:
         ExtraLifePowerUp();
@@ -34,16 +32,13 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         sf::Color getAuraColor() const override { return sf::Color::Green; }
 
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
-
     private:
         float m_heartbeatAnimation;
         static constexpr float m_heartbeatSpeed = Constants::EXTRA_LIFE_HEARTBEAT_SPEED;
     };
 
     // Speed Boost Power-up - increases player speed
-    class SpeedBoostPowerUp : public PowerUp
+    class SpeedBoostPowerUp : public PowerUp, public SpriteDrawable<SpeedBoostPowerUp>
     {
     public:
         SpeedBoostPowerUp();
@@ -51,9 +46,6 @@ namespace FishGame
 
         void update(sf::Time deltaTime) override;
         sf::Color getAuraColor() const override { return sf::Color(0, 255, 255); }
-
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
         float m_lineAnimation;

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -2,6 +2,7 @@
 
 #include "BonusItem.h"
 #include "SpriteComponent.h"
+#include "Utils/SpriteDrawable.h"
 
 namespace FishGame
 {
@@ -41,7 +42,7 @@ namespace FishGame
     };
 
     // Score Doubler - doubles all points for duration
-    class ScoreDoublerPowerUp : public PowerUp
+    class ScoreDoublerPowerUp : public PowerUp, public SpriteDrawable<ScoreDoublerPowerUp>
     {
     public:
         ScoreDoublerPowerUp();
@@ -52,12 +53,10 @@ namespace FishGame
 
         void setFont(const sf::Font& font) {}
 
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
     };
 
     // Frenzy Starter - instantly activates Frenzy Mode
-    class FrenzyStarterPowerUp : public PowerUp
+    class FrenzyStarterPowerUp : public PowerUp, public SpriteDrawable<FrenzyStarterPowerUp>
     {
     public:
         FrenzyStarterPowerUp();
@@ -65,9 +64,6 @@ namespace FishGame
 
         void update(sf::Time deltaTime) override;
         sf::Color getAuraColor() const override { return sf::Color::Magenta; }
-
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
         float m_sparkAnimation;
@@ -118,16 +114,22 @@ namespace FishGame
         std::vector<ActivePowerUp> m_activePowerUps;
 
         // Use template to find power-up in vector
+        template<typename Predicate, typename Container>
+        static auto findPowerUpImpl(Container& container, Predicate pred)
+        {
+            return std::find_if(container.begin(), container.end(), pred);
+        }
+
         template<typename Predicate>
         auto findPowerUp(Predicate pred)
         {
-            return std::find_if(m_activePowerUps.begin(), m_activePowerUps.end(), pred);
+            return findPowerUpImpl(m_activePowerUps, pred);
         }
 
         template<typename Predicate>
         auto findPowerUp(Predicate pred) const
         {
-            return std::find_if(m_activePowerUps.begin(), m_activePowerUps.end(), pred);
+            return findPowerUpImpl(m_activePowerUps, pred);
         }
     };
 }

--- a/include/Managers/BonusItemManager.h
+++ b/include/Managers/BonusItemManager.h
@@ -4,6 +4,7 @@
 #include "PowerUp.h"
 #include <vector>
 #include <algorithm>
+#include <functional>
 
 namespace FishGame
 {
@@ -173,6 +174,12 @@ namespace FishGame
         void updatePowerUpSpawning(sf::Time deltaTime);
         std::unique_ptr<PowerUp> createRandomPowerUp();
 
+        template<typename T, typename Init = std::function<void(T&)>>
+        void spawnItem(Init init = {});
+
+        template<typename T>
+        void addItem(std::unique_ptr<T> item);
+
     private:
         const sf::Font& m_font;
         sf::Vector2u m_windowSize;
@@ -198,6 +205,26 @@ namespace FishGame
         // Base spawn rates
         static constexpr float m_baseStarfishRate = 0.2f;
         static constexpr float m_baseOysterRate = 0.1f;
-        static constexpr float m_basePowerUpInterval = 20.0f;
+    static constexpr float m_basePowerUpInterval = 20.0f;
     };
+
+    template<typename T, typename Init>
+    void BonusItemManager::spawnItem(Init init)
+    {
+        auto item = std::make_unique<T>();
+        if (init)
+            init(*item);
+        addItem(std::move(item));
+    }
+
+    template<typename T>
+    void BonusItemManager::addItem(std::unique_ptr<T> item)
+    {
+        if (!item)
+            return;
+        float x = m_positionDist(m_randomEngine);
+        float y = m_positionDist(m_randomEngine);
+        item->setPosition(x, y);
+        m_spawnedItems.push_back(std::move(item));
+    }
 }

--- a/include/Utils/SpriteDrawable.h
+++ b/include/Utils/SpriteDrawable.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "DrawHelpers.h"
+#include <SFML/Graphics.hpp>
+
+namespace FishGame
+{
+    // Mixin that provides a default draw implementation for
+    // entities with a sprite component
+    template<class Derived>
+    class SpriteDrawable
+    {
+    protected:
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const
+        {
+            DrawUtils::drawSpriteIfPresent(static_cast<const Derived&>(*this), target, states);
+        }
+    };
+}

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -117,10 +117,6 @@ void BonusItem::onCollect()
 
     }
 
-    void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        DrawUtils::drawSpriteIfPresent(*this, target, states);
-    }
 
     // PearlOyster implementation
     PearlOyster::PearlOyster()

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -17,10 +17,6 @@ void FreezePowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 2.0f);
 }
 
-    void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        DrawUtils::drawSpriteIfPresent(*this, target, states);
-    }
 
     // ExtraLifePowerUp implementation
     ExtraLifePowerUp::ExtraLifePowerUp()
@@ -40,10 +36,6 @@ void ExtraLifePowerUp::update(sf::Time deltaTime)
     }
 }
 
-    void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        DrawUtils::drawSpriteIfPresent(*this, target, states);
-    }
 
     // SpeedBoostPowerUp implementation
     SpeedBoostPowerUp::SpeedBoostPowerUp()
@@ -58,8 +50,4 @@ void SpeedBoostPowerUp::update(sf::Time deltaTime)
     m_lineAnimation += deltaTime.asSeconds() * 5.0f;
 }
 
-    void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        DrawUtils::drawSpriteIfPresent(*this, target, states);
-    }
 }

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -45,10 +45,6 @@ void ScoreDoublerPowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 3.0f);
 }
 
-    void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        DrawUtils::drawSpriteIfPresent(*this, target, states);
-    }
 
     // FrenzyStarterPowerUp implementation
     FrenzyStarterPowerUp::FrenzyStarterPowerUp()
@@ -63,10 +59,6 @@ void FrenzyStarterPowerUp::update(sf::Time deltaTime)
     m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
 }
 
-    void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        DrawUtils::drawSpriteIfPresent(*this, target, states);
-    }
 
     // PowerUpManager implementation
     PowerUpManager::PowerUpManager()

--- a/src/Managers/BonusItemManager.cpp
+++ b/src/Managers/BonusItemManager.cpp
@@ -108,37 +108,23 @@ namespace FishGame
 
     void BonusItemManager::spawnStarfish()
     {
-        auto starfish = std::make_unique<Starfish>();
-
-        float x = m_positionDist(m_randomEngine);
-        float y = m_positionDist(m_randomEngine);
-        starfish->setPosition(x, y);
-        if (m_spriteManager)
-            starfish->initializeSprite(*m_spriteManager);
-
-        m_spawnedItems.push_back(std::move(starfish));
+        spawnItem<Starfish>([this](Starfish& s)
+            {
+                if (m_spriteManager)
+                    s.initializeSprite(*m_spriteManager);
+            });
     }
 
     void BonusItemManager::spawnOyster()
     {
-        auto oyster = std::make_unique<PearlOyster>();
-
-        float x = m_positionDist(m_randomEngine);
-        float y = m_positionDist(m_randomEngine);
-        oyster->setPosition(x, y);
-
-        m_spawnedItems.push_back(std::move(oyster));
+        spawnItem<PearlOyster>();
     }
 
     void BonusItemManager::spawnRandomPowerUp()
     {
         if (auto powerUp = createRandomPowerUp())
         {
-            float x = m_positionDist(m_randomEngine);
-            float y = m_positionDist(m_randomEngine);
-            powerUp->setPosition(x, y);
-
-            m_spawnedItems.push_back(std::move(powerUp));
+            addItem(std::move(powerUp));
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce `SpriteDrawable` mixin to remove repeated draw functions
- template spawn helpers in `BonusItemManager`
- refactor power-up manager helper and update entity headers
- simplify bonus item spawning logic

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68544f5ca2fc83339c6ad77a09512046