### PR TITLE
Fix draw overrides and template

### DIFF
--- a/include/Entities/BonusItem.h
+++ b/include/Entities/BonusItem.h
@@ -66,6 +66,7 @@ namespace FishGame
         void initializeSprite(SpriteManager& spriteManager);
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
         float m_rotation;

--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -14,6 +14,7 @@ namespace FishGame
         ~FreezePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Cyan; }
 
         void setFont(const sf::Font& font) {}
@@ -30,6 +31,7 @@ namespace FishGame
         ~ExtraLifePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Green; }
 
     private:
@@ -45,6 +47,7 @@ namespace FishGame
         ~SpeedBoostPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color(0, 255, 255); }
 
     private:

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -49,6 +49,7 @@ namespace FishGame
         ~ScoreDoublerPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Yellow; }
 
         void setFont(const sf::Font& font) {}
@@ -63,6 +64,7 @@ namespace FishGame
         ~FrenzyStarterPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Magenta; }
 
     private:

--- a/include/Managers/BonusItemManager.h
+++ b/include/Managers/BonusItemManager.h
@@ -174,8 +174,8 @@ namespace FishGame
         void updatePowerUpSpawning(sf::Time deltaTime);
         std::unique_ptr<PowerUp> createRandomPowerUp();
 
-        template<typename T, typename Init = std::function<void(T&)>>
-        void spawnItem(Init init = {});
+        template<typename T>
+        void spawnItem(std::function<void(T&)> init = {});
 
         template<typename T>
         void addItem(std::unique_ptr<T> item);
@@ -208,8 +208,8 @@ namespace FishGame
     static constexpr float m_basePowerUpInterval = 20.0f;
     };
 
-    template<typename T, typename Init>
-    void BonusItemManager::spawnItem(Init init)
+    template<typename T>
+    void BonusItemManager::spawnItem(std::function<void(T&)> init)
     {
         auto item = std::make_unique<T>();
         if (init)

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -98,8 +98,8 @@ void BonusItem::onCollect()
         }
     }
 
-    void Starfish::update(sf::Time deltaTime)
-    {
+void Starfish::update(sf::Time deltaTime)
+{
         if (!updateLifetime(deltaTime))
             return;
 
@@ -116,6 +116,11 @@ void BonusItem::onCollect()
         m_position.y = m_baseY + computeBobbingOffset();
 
     }
+
+void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<Starfish>::draw(target, states);
+}
 
 
     // PearlOyster implementation

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -17,6 +17,11 @@ void FreezePowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 2.0f);
 }
 
+void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<FreezePowerUp>::draw(target, states);
+}
+
 
     // ExtraLifePowerUp implementation
     ExtraLifePowerUp::ExtraLifePowerUp()
@@ -36,6 +41,11 @@ void ExtraLifePowerUp::update(sf::Time deltaTime)
     }
 }
 
+void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<ExtraLifePowerUp>::draw(target, states);
+}
+
 
     // SpeedBoostPowerUp implementation
     SpeedBoostPowerUp::SpeedBoostPowerUp()
@@ -48,6 +58,11 @@ void SpeedBoostPowerUp::update(sf::Time deltaTime)
 {
     commonUpdate(deltaTime, 4.0f, 1.5f);
     m_lineAnimation += deltaTime.asSeconds() * 5.0f;
+}
+
+void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<SpeedBoostPowerUp>::draw(target, states);
 }
 
 }

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -45,6 +45,11 @@ void ScoreDoublerPowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 3.0f);
 }
 
+void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<ScoreDoublerPowerUp>::draw(target, states);
+}
+
 
     // FrenzyStarterPowerUp implementation
     FrenzyStarterPowerUp::FrenzyStarterPowerUp()
@@ -57,6 +62,11 @@ void FrenzyStarterPowerUp::update(sf::Time deltaTime)
 {
     commonUpdate(deltaTime, 4.0f, 2.0f);
     m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
+}
+
+void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<FrenzyStarterPowerUp>::draw(target, states);
 }
 
 


### PR DESCRIPTION
## Summary
- add `draw` overrides for bonus item classes
- fix `spawnItem` template to always use `std::function`

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6854520937348333b8b5fa9cc5655016