### PR TITLE
Refactor sprite drawing with template

### DIFF
--- a/include/Entities/BonusItem.h
+++ b/include/Entities/BonusItem.h
@@ -56,7 +56,7 @@ namespace FishGame
     };
 
     // Starfish bonus item - fixed points
-    class Starfish : public BonusItem, public SpriteDrawable<Starfish>
+    class Starfish : public BonusItem, public AutoSpriteDrawable<Starfish>
     {
     public:
         Starfish();
@@ -66,7 +66,6 @@ namespace FishGame
         void initializeSprite(SpriteManager& spriteManager);
 
         void update(sf::Time deltaTime) override;
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
         float m_rotation;

--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -7,14 +7,13 @@
 namespace FishGame
 {
     // Freeze Power-up - freezes all enemy fish temporarily
-    class FreezePowerUp : public PowerUp, public SpriteDrawable<FreezePowerUp>
+    class FreezePowerUp : public PowerUp, public AutoSpriteDrawable<FreezePowerUp>
     {
     public:
         FreezePowerUp();
         ~FreezePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Cyan; }
 
         void setFont(const sf::Font& font) {}
@@ -24,14 +23,13 @@ namespace FishGame
     };
 
     // Extra Life Power-up - grants an additional life
-    class ExtraLifePowerUp : public PowerUp, public SpriteDrawable<ExtraLifePowerUp>
+    class ExtraLifePowerUp : public PowerUp, public AutoSpriteDrawable<ExtraLifePowerUp>
     {
     public:
         ExtraLifePowerUp();
         ~ExtraLifePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Green; }
 
     private:
@@ -40,14 +38,13 @@ namespace FishGame
     };
 
     // Speed Boost Power-up - increases player speed
-    class SpeedBoostPowerUp : public PowerUp, public SpriteDrawable<SpeedBoostPowerUp>
+    class SpeedBoostPowerUp : public PowerUp, public AutoSpriteDrawable<SpeedBoostPowerUp>
     {
     public:
         SpeedBoostPowerUp();
         ~SpeedBoostPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color(0, 255, 255); }
 
     private:

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -42,14 +42,13 @@ namespace FishGame
     };
 
     // Score Doubler - doubles all points for duration
-    class ScoreDoublerPowerUp : public PowerUp, public SpriteDrawable<ScoreDoublerPowerUp>
+    class ScoreDoublerPowerUp : public PowerUp, public AutoSpriteDrawable<ScoreDoublerPowerUp>
     {
     public:
         ScoreDoublerPowerUp();
         ~ScoreDoublerPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Yellow; }
 
         void setFont(const sf::Font& font) {}
@@ -57,14 +56,13 @@ namespace FishGame
     };
 
     // Frenzy Starter - instantly activates Frenzy Mode
-    class FrenzyStarterPowerUp : public PowerUp, public SpriteDrawable<FrenzyStarterPowerUp>
+    class FrenzyStarterPowerUp : public PowerUp, public AutoSpriteDrawable<FrenzyStarterPowerUp>
     {
     public:
         FrenzyStarterPowerUp();
         ~FrenzyStarterPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Magenta; }
 
     private:

--- a/include/Utils/SpriteDrawable.h
+++ b/include/Utils/SpriteDrawable.h
@@ -16,4 +16,18 @@ namespace FishGame
             DrawUtils::drawSpriteIfPresent(static_cast<const Derived&>(*this), target, states);
         }
     };
+
+    // Helper base that automatically provides the required draw override
+    // for entity classes. This removes the need for each entity to
+    // implement a trivial draw method that simply delegates to
+    // SpriteDrawable.
+    template<class Derived>
+    class AutoSpriteDrawable : public SpriteDrawable<Derived>
+    {
+    protected:
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+        {
+            SpriteDrawable<Derived>::draw(target, states);
+        }
+    };
 }

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -117,12 +117,6 @@ void Starfish::update(sf::Time deltaTime)
 
     }
 
-void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
-    SpriteDrawable<Starfish>::draw(target, states);
-}
-
-
     // PearlOyster implementation
     PearlOyster::PearlOyster()
         : BonusItem(BonusType::PearlOyster, 0)

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -17,10 +17,6 @@ void FreezePowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 2.0f);
 }
 
-void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
-    SpriteDrawable<FreezePowerUp>::draw(target, states);
-}
 
 
     // ExtraLifePowerUp implementation
@@ -41,10 +37,6 @@ void ExtraLifePowerUp::update(sf::Time deltaTime)
     }
 }
 
-void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
-    SpriteDrawable<ExtraLifePowerUp>::draw(target, states);
-}
 
 
     // SpeedBoostPowerUp implementation
@@ -60,9 +52,5 @@ void SpeedBoostPowerUp::update(sf::Time deltaTime)
     m_lineAnimation += deltaTime.asSeconds() * 5.0f;
 }
 
-void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
-    SpriteDrawable<SpeedBoostPowerUp>::draw(target, states);
-}
 
 }

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -45,10 +45,6 @@ void ScoreDoublerPowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 3.0f);
 }
 
-void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
-    SpriteDrawable<ScoreDoublerPowerUp>::draw(target, states);
-}
 
 
     // FrenzyStarterPowerUp implementation
@@ -64,10 +60,6 @@ void FrenzyStarterPowerUp::update(sf::Time deltaTime)
     m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
 }
 
-void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
-    SpriteDrawable<FrenzyStarterPowerUp>::draw(target, states);
-}
 
 
     // PowerUpManager implementation


### PR DESCRIPTION
## Summary
- add `AutoSpriteDrawable` mixin for automatic draw override
- use the mixin in starfish and all power-up classes
- remove now unnecessary draw method definitions

## Testing
- `cmake --preset x64-Debug` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685454627c6c8333a7dee6eb0e09c01a