### PR TITLE
Fix abstract class errors by restoring draw overrides

### DIFF
--- a/include/Entities/BonusItem.h
+++ b/include/Entities/BonusItem.h
@@ -56,7 +56,7 @@ namespace FishGame
     };
 
     // Starfish bonus item - fixed points
-    class Starfish : public BonusItem, public AutoSpriteDrawable<Starfish>
+    class Starfish : public BonusItem, public SpriteDrawable<Starfish>
     {
     public:
         Starfish();
@@ -66,6 +66,7 @@ namespace FishGame
         void initializeSprite(SpriteManager& spriteManager);
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
         float m_rotation;

--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -7,13 +7,14 @@
 namespace FishGame
 {
     // Freeze Power-up - freezes all enemy fish temporarily
-    class FreezePowerUp : public PowerUp, public AutoSpriteDrawable<FreezePowerUp>
+    class FreezePowerUp : public PowerUp, public SpriteDrawable<FreezePowerUp>
     {
     public:
         FreezePowerUp();
         ~FreezePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Cyan; }
 
         void setFont(const sf::Font& font) {}
@@ -23,13 +24,14 @@ namespace FishGame
     };
 
     // Extra Life Power-up - grants an additional life
-    class ExtraLifePowerUp : public PowerUp, public AutoSpriteDrawable<ExtraLifePowerUp>
+    class ExtraLifePowerUp : public PowerUp, public SpriteDrawable<ExtraLifePowerUp>
     {
     public:
         ExtraLifePowerUp();
         ~ExtraLifePowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Green; }
 
     private:
@@ -38,13 +40,14 @@ namespace FishGame
     };
 
     // Speed Boost Power-up - increases player speed
-    class SpeedBoostPowerUp : public PowerUp, public AutoSpriteDrawable<SpeedBoostPowerUp>
+    class SpeedBoostPowerUp : public PowerUp, public SpriteDrawable<SpeedBoostPowerUp>
     {
     public:
         SpeedBoostPowerUp();
         ~SpeedBoostPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color(0, 255, 255); }
 
     private:

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -42,13 +42,14 @@ namespace FishGame
     };
 
     // Score Doubler - doubles all points for duration
-    class ScoreDoublerPowerUp : public PowerUp, public AutoSpriteDrawable<ScoreDoublerPowerUp>
+    class ScoreDoublerPowerUp : public PowerUp, public SpriteDrawable<ScoreDoublerPowerUp>
     {
     public:
         ScoreDoublerPowerUp();
         ~ScoreDoublerPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Yellow; }
 
         void setFont(const sf::Font& font) {}
@@ -56,13 +57,14 @@ namespace FishGame
     };
 
     // Frenzy Starter - instantly activates Frenzy Mode
-    class FrenzyStarterPowerUp : public PowerUp, public AutoSpriteDrawable<FrenzyStarterPowerUp>
+    class FrenzyStarterPowerUp : public PowerUp, public SpriteDrawable<FrenzyStarterPowerUp>
     {
     public:
         FrenzyStarterPowerUp();
         ~FrenzyStarterPowerUp() override = default;
 
         void update(sf::Time deltaTime) override;
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         sf::Color getAuraColor() const override { return sf::Color::Magenta; }
 
     private:

--- a/include/Utils/SpriteDrawable.h
+++ b/include/Utils/SpriteDrawable.h
@@ -17,17 +17,9 @@ namespace FishGame
         }
     };
 
-    // Helper base that automatically provides the required draw override
-    // for entity classes. This removes the need for each entity to
-    // implement a trivial draw method that simply delegates to
-    // SpriteDrawable.
-    template<class Derived>
-    class AutoSpriteDrawable : public SpriteDrawable<Derived>
-    {
-    protected:
-        void draw(sf::RenderTarget& target, sf::RenderStates states) const override
-        {
-            SpriteDrawable<Derived>::draw(target, states);
-        }
-    };
+    // Helper base that used to automatically provide the required draw
+    // override for entity classes. This approach caused multiple
+    // inheritance issues on some compilers, so each entity now provides
+    // its own draw implementation using the SpriteDrawable mixin
+    // directly.
 }

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -117,6 +117,11 @@ void Starfish::update(sf::Time deltaTime)
 
     }
 
+void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<Starfish>::draw(target, states);
+}
+
     // PearlOyster implementation
     PearlOyster::PearlOyster()
         : BonusItem(BonusType::PearlOyster, 0)

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -17,6 +17,11 @@ void FreezePowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 2.0f);
 }
 
+void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<FreezePowerUp>::draw(target, states);
+}
+
 
 
     // ExtraLifePowerUp implementation
@@ -37,6 +42,11 @@ void ExtraLifePowerUp::update(sf::Time deltaTime)
     }
 }
 
+void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<ExtraLifePowerUp>::draw(target, states);
+}
+
 
 
     // SpeedBoostPowerUp implementation
@@ -50,6 +60,11 @@ void SpeedBoostPowerUp::update(sf::Time deltaTime)
 {
     commonUpdate(deltaTime, 4.0f, 1.5f);
     m_lineAnimation += deltaTime.asSeconds() * 5.0f;
+}
+
+void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<SpeedBoostPowerUp>::draw(target, states);
 }
 
 

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -45,6 +45,11 @@ void ScoreDoublerPowerUp::update(sf::Time deltaTime)
     commonUpdate(deltaTime, 3.0f);
 }
 
+void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<ScoreDoublerPowerUp>::draw(target, states);
+}
+
 
 
     // FrenzyStarterPowerUp implementation
@@ -58,6 +63,11 @@ void FrenzyStarterPowerUp::update(sf::Time deltaTime)
 {
     commonUpdate(deltaTime, 4.0f, 2.0f);
     m_sparkAnimation += deltaTime.asSeconds() * 10.0f;
+}
+
+void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    SpriteDrawable<FrenzyStarterPowerUp>::draw(target, states);
 }
 
 


### PR DESCRIPTION
## Summary
- revert mixin usage that caused abstract class errors
- add explicit draw overrides for all relevant entity classes
- remove unused AutoSpriteDrawable helper

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6854581860c88333ac33dd2e962c8420