### PR TITLE
Fix particle initialization

### DIFF
--- a/src/States/GameOverState.cpp
+++ b/src/States/GameOverState.cpp
@@ -196,11 +196,10 @@ namespace FishGame
     {
         // Initialize some particles
         size_t initialParticles = m_maxParticles / 2;
-        std::for_each_n(std::make_counting_iterator<size_t>(0), initialParticles,
-            [this](size_t)
-            {
-                spawnParticle(m_randomEngine);
-            });
+        for (size_t i = 0; i < initialParticles; ++i)
+        {
+            spawnParticle(m_randomEngine);
+        }
     }
 
     void GameOverState::createStatText(const std::string& label, const std::string& value, float yPos)


### PR DESCRIPTION
## Summary
- fix compilation by replacing `std::make_counting_iterator` usage with a normal loop in GameOverState

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_685460289b9883338db8f9a43aef9515