### PR TITLE
Fix lambda capture in Player input

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -231,7 +231,7 @@ namespace FishGame
 
         sf::Vector2f inputDirection = std::accumulate(
             m_pressedKeys.begin(), m_pressedKeys.end(), sf::Vector2f{0.f, 0.f},
-            [&keyMap](sf::Vector2f sum, sf::Keyboard::Key key)
+            [](sf::Vector2f sum, sf::Keyboard::Key key)
             {
                 auto it = keyMap.find(key);
                 if (it != keyMap.end())


### PR DESCRIPTION
## Summary
- resolve compilation error in `Player::handleInput` by removing invalid capture of a `static` variable

## Testing
- `cmake --preset x64-Debug` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68546393c1e083339a9baecfe2f6505a