### PR TITLE
Fix freeze power-up behavior

### DIFF
--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -469,22 +469,15 @@ namespace FishGame
 
     void PlayState::updateAllEntities(sf::Time deltaTime)
     {
-        // Update all entities with freeze effect
-        auto freezeModifier = m_isPlayerFrozen ? 0.1f : 1.0f;
-
+        // Update regular entity logic
         StateUtils::updateEntities(m_entities, deltaTime);
         StateUtils::updateEntities(m_bonusItems, deltaTime);
         StateUtils::updateEntities(m_hazards, deltaTime);
 
         // Apply specific AI updates and effects
-        StateUtils::applyToEntities(m_entities, [this, deltaTime, freezeModifier](Entity& entity) {
+        StateUtils::applyToEntities(m_entities, [this, deltaTime](Entity& entity) {
             if (auto* fish = dynamic_cast<Fish*>(&entity))
             {
-                if (m_isPlayerFrozen)
-                {
-                    fish->setVelocity(fish->getVelocity() * freezeModifier);
-                }
-
                 if (!fish->isStunned())
                 {
                     fish->updateAI(m_entities, m_player.get(), deltaTime);
@@ -505,7 +498,7 @@ namespace FishGame
                 StateUtils::applyToEntities(m_entities, [](Entity& entity) {
                     if (auto* fish = dynamic_cast<Fish*>(&entity))
                     {
-                        fish->setVelocity(fish->getVelocity() * 10.0f);
+                        fish->setFrozen(false);
                     }
                     });
             }
@@ -918,12 +911,12 @@ namespace FishGame
     void PlayState::applyFreeze()
     {
         m_isPlayerFrozen = true;
-        m_freezeTimer = sf::seconds(5.0f);
+        m_freezeTimer = sf::seconds(Constants::FREEZE_POWERUP_DURATION);
 
-        StateUtils::applyToEntities(m_entities, [](Entity& entity) {    
+        StateUtils::applyToEntities(m_entities, [](Entity& entity) {
             if (auto* fish = dynamic_cast<Fish*>(&entity))
             {
-                fish->setVelocity(fish->getVelocity() * 0.1f);
+                fish->setFrozen(true);
             }
             });
     }


### PR DESCRIPTION
## Summary
- fix freeze behavior so fish stay frozen for 5s and then resume

## Testing
- `cmake -B build -S .` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6854650b82f48333b8d58d50326c83fc