### PR TITLE
Fix diagonal movement input

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -222,21 +222,27 @@ namespace FishGame
 
     void Player::handleInput()
     {
-        static const std::unordered_map<sf::Keyboard::Key, sf::Vector2f> keyMap = {
-            {sf::Keyboard::W, {0.f, -1.f}}, {sf::Keyboard::Up, {0.f, -1.f}},
-            {sf::Keyboard::S, {0.f, 1.f}},  {sf::Keyboard::Down, {0.f, 1.f}},
-            {sf::Keyboard::A, {-1.f, 0.f}}, {sf::Keyboard::Left, {-1.f, 0.f}},
-            {sf::Keyboard::D, {1.f, 0.f}},  {sf::Keyboard::Right, {1.f, 0.f}}
-        };
-
         sf::Vector2f inputDirection{ 0.f, 0.f };
-        for (const auto& key : m_pressedKeys)
+
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::W) ||
+            sf::Keyboard::isKeyPressed(sf::Keyboard::Up))
         {
-            auto it = keyMap.find(key);
-            if (it != keyMap.end())
-            {
-                inputDirection += it->second;
-            }
+            inputDirection.y -= 1.f;
+        }
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::S) ||
+            sf::Keyboard::isKeyPressed(sf::Keyboard::Down))
+        {
+            inputDirection.y += 1.f;
+        }
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::A) ||
+            sf::Keyboard::isKeyPressed(sf::Keyboard::Left))
+        {
+            inputDirection.x -= 1.f;
+        }
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::D) ||
+            sf::Keyboard::isKeyPressed(sf::Keyboard::Right))
+        {
+            inputDirection.x += 1.f;
         }
 
         if (m_controlsReversed)


### PR DESCRIPTION
## Summary
- adjust Player input to poll real-time keyboard state instead of relying on event queue

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68546bc57dac83339f5762e140b4c1bd