### PR TITLE
Fix diagonal movement input

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -230,12 +230,26 @@ namespace FishGame
         };
 
         sf::Vector2f inputDirection{ 0.f, 0.f };
-        for (const auto& key : m_pressedKeys)
+        if (!m_pressedKeys.empty())
         {
-            auto it = keyMap.find(key);
-            if (it != keyMap.end())
+            for (const auto& key : m_pressedKeys)
             {
-                inputDirection += it->second;
+                auto it = keyMap.find(key);
+                if (it != keyMap.end())
+                {
+                    inputDirection += it->second;
+                }
+            }
+        }
+        else
+        {
+            // Fallback to real-time polling if no events were captured
+            for (const auto& [key, dir] : keyMap)
+            {
+                if (sf::Keyboard::isKeyPressed(key))
+                {
+                    inputDirection += dir;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- refine `Player::handleInput` to merge keyboard events with real-time polling

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68546bc57dac83339f5762e140b4c1bd