### PR TITLE
Fix diagonal movement input

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -230,12 +230,11 @@ namespace FishGame
         };
 
         sf::Vector2f inputDirection{ 0.f, 0.f };
-        for (const auto& key : m_pressedKeys)
+        for (const auto& [key, dir] : keyMap)
         {
-            auto it = keyMap.find(key);
-            if (it != keyMap.end())
+            if (sf::Keyboard::isKeyPressed(key))
             {
-                inputDirection += it->second;
+                inputDirection += dir;
             }
         }
 


### PR DESCRIPTION
## Summary
- refine `Player::handleInput` to poll keyboard state directly

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68546bc57dac83339f5762e140b4c1bd