### PR TITLE
Fix jellyfish stun resets player input

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -33,6 +33,8 @@ namespace FishGame
         void handleInput();
         void onKeyPressed(sf::Keyboard::Key key);
         void onKeyReleased(sf::Keyboard::Key key);
+        // Clear any cached input states
+        void clearInput();
         void followMouse(const sf::Vector2f& mousePosition);
         sf::Vector2f getTargetPosition() const { return m_targetPosition; }
         bool isUsingMouseControl() const { return m_useMouseControl; }

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -282,6 +282,11 @@ namespace FishGame
         m_pressedKeys.erase(key);
     }
 
+    void Player::clearInput()
+    {
+        m_pressedKeys.clear();
+    }
+
     void Player::followMouse(const sf::Vector2f& mousePosition)
     {
         m_targetPosition = mousePosition;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -840,6 +840,7 @@ namespace FishGame
                 state->m_isPlayerStunned = true;
                 state->m_stunTimer = jelly->getStunDuration();
                 state->m_player->setVelocity(0.0f, 0.0f);
+                state->m_player->clearInput();
                 state->createParticleEffect(state->m_player->getPosition(), sf::Color(255, 255, 0, 150), 10);
             }
             break;


### PR DESCRIPTION
## Summary
- add clearInput method to Player to reset cached key states
- call clearInput when the player gets stunned by a jellyfish

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_68547920f1288333be6f7d4018c3dfdc