### PR TITLE
Add poison velocity reversal

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -608,6 +608,8 @@ sf::FloatRect Player::getBounds() const
     void Player::applyPoisonEffect(sf::Time duration)
     {
         m_poisonColorTimer = duration;
+        // Reverse current movement direction immediately
+        m_velocity = -m_velocity;
         m_controlsReversed = true;
     }
 


### PR DESCRIPTION
## Summary
- reverse player's velocity when poison effect is applied

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68547da813b883339e7df020a45b4035