### PR TITLE
Add MediumFish color variants

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -74,6 +74,10 @@ namespace FishGame
         void updateVisualState();
         void playEatAnimation();
 
+        // Base color for sprite
+        void setBaseColor(const sf::Color& color);
+        const sf::Color& getBaseColor() const { return m_baseColor; }
+
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         void updateMovement(sf::Time deltaTime);
@@ -114,6 +118,9 @@ namespace FishGame
 
         // Additional member for damage flash effect
         sf::Time m_damageFlashTimer;
+
+        // Base color used when no special state is active
+        sf::Color m_baseColor;
 
         // Animation support
         std::unique_ptr<Animator> m_animator;

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -29,6 +29,7 @@ namespace FishGame
         , m_isFrozen(false)
         , m_velocityBeforeFreeze(0.0f, 0.0f)
         , m_damageFlashTimer(sf::Time::Zero)
+        , m_baseColor(sf::Color::White)
         , m_eating(false)
         , m_eatTimer(sf::Time::Zero)
     {
@@ -111,7 +112,7 @@ namespace FishGame
         if (m_sprite)
         {
             // Update sprite color based on state
-            sf::Color spriteColor = sf::Color::White;
+            sf::Color spriteColor = m_baseColor;
 
             if (m_isPoisoned)
             {
@@ -565,5 +566,14 @@ namespace FishGame
             }
         }
         return 1; // Default
+    }
+
+    void Fish::setBaseColor(const sf::Color& color)
+    {
+        m_baseColor = color;
+        if (m_sprite)
+        {
+            m_sprite->setColor(color);
+        }
     }
 }

--- a/src/Managers/FishSpawner.cpp
+++ b/src/Managers/FishSpawner.cpp
@@ -2,6 +2,7 @@
 #include "GameConstants.h"
 #include "SpriteManager.h"
 #include <algorithm>
+#include <array>
 
 namespace FishGame
 {
@@ -101,6 +102,15 @@ namespace FishGame
             fish.setDirection(mediumConfig.fromLeft ? 1.0f : -1.0f, 0.0f);
             fish.setWindowBounds(m_windowSize);
             fish.initializeSprite(*m_spriteManager);
+
+            static const std::array<sf::Color, 4> colors = {
+                sf::Color::White,
+                sf::Color::Red,
+                sf::Color::Cyan,
+                sf::Color(200, 255, 255)
+            };
+            std::uniform_int_distribution<int> dist(0, colors.size() - 1);
+            fish.setBaseColor(colors[dist(m_randomEngine)]);
             };
 
         m_mediumSpawner.setConfig(mediumSpawnerConfig);


### PR DESCRIPTION
## Summary
- introduce base color tracking for `Fish`
- expose `setBaseColor` and apply it in `updateVisualState`
- spawn `MediumFish` with random tint (OG, red, cyan, very pale cyan)

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68551f2935048333874ccc6e01c54bed