### PR TITLE
Replace power‑up circles with sprites

### DIFF
--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -147,6 +147,12 @@ namespace FishGame
             config.scaleMultiplier = getScaleForSize(size) * 1.3f;
             break;
 
+        case TextureID::PowerUpExtraLife:
+        case TextureID::PowerUpSpeedBoost:
+            // Power-up sprites appear small by default, scale them up
+            config.scaleMultiplier = 2.0f;
+            break;
+
         case TextureID::Starfish:
             config.baseSize = sf::Vector2f(50.0f, 50.0f);
             config.rotationOffset = 0.0f; // Will be animated

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -585,9 +585,17 @@ namespace FishGame
             break;
         case 1:
             powerUp = std::make_unique<ExtraLifePowerUp>();
+            if (auto* life = dynamic_cast<ExtraLifePowerUp*>(powerUp.get()))
+            {
+                life->initializeSprite(getGame().getSpriteManager());
+            }
             break;
         case 2:
             powerUp = std::make_unique<SpeedBoostPowerUp>();
+            if (auto* speed = dynamic_cast<SpeedBoostPowerUp*>(powerUp.get()))
+            {
+                speed->initializeSprite(getGame().getSpriteManager());
+            }
             break;
         }
 


### PR DESCRIPTION
## Summary
- use sprite textures for the speed and extra-life power-ups
- double the sprite scale for these textures

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6856a582268c83339893643d9f8e34be