### PR TITLE
Add Bomb sprite animation support

### DIFF
--- a/include/Entities/Hazard.h
+++ b/include/Entities/Hazard.h
@@ -3,6 +3,8 @@
 #include "Entity.h"
 #include <vector>
 #include <random>
+#include <memory>
+#include "Utils/AnimatedSprite.h"
 
 namespace FishGame
 {
@@ -40,10 +42,18 @@ namespace FishGame
         Bomb();
         ~Bomb() override = default;
 
+        // Sprite setup
+        void initializeSprite(SpriteManager& spriteManager);
+
         void update(sf::Time deltaTime) override;
         sf::FloatRect getBounds() const override;
         void onContact(Entity& entity) override;
 
+        // Control the explosion sequence
+        void trigger();
+        bool isFinished() const;
+
+        // Compatibility with old systems
         bool isExploding() const { return m_isExploding; }
         float getExplosionRadius() const { return m_explosionRadius; }
 
@@ -51,21 +61,23 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        void createExplosion();
+        enum class State { IdleBomb, Explode, Puffs, Smoke, Done };
 
-    private:
-        sf::CircleShape m_bombShape;
-        sf::CircleShape m_fuseGlow;
-        std::vector<sf::CircleShape> m_explosionParticles;
+        void advanceState();
+
+        // Animation
+        std::unique_ptr<class AnimatedSprite> m_sprite;
+        State m_state;
+        int m_puffLoops;
 
         bool m_isExploding;
-        sf::Time m_explosionTimer;
+        sf::Time m_stateTimer;
         float m_explosionRadius;
-        float m_pulseAnimation;
 
         static constexpr float m_baseRadius = 20.0f;
-        static constexpr float m_maxExplosionRadius = 100.0f;
-        static constexpr float m_fuseDuration = 3.0f;
+        static constexpr float m_explosionDuration = 0.4f; // 5 frames * 0.08s
+        static constexpr int m_maxPuffLoops = 3;
+        static constexpr float m_puffFrameTime = 0.1f;
     };
 
     // Jellyfish - stuns on contact

--- a/include/Utils/AnimatedSprite.h
+++ b/include/Utils/AnimatedSprite.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <unordered_map>
+#include <vector>
+#include <string>
+
+class AnimatedSprite : public sf::Drawable
+{
+public:
+    struct Animation
+    {
+        std::vector<sf::IntRect> frames;
+        sf::Time frameTime{};
+        bool loop{true};
+    };
+
+    explicit AnimatedSprite(const sf::Texture& texture);
+
+    void addAnimation(const std::string& name, const Animation& anim);
+    void play(const std::string& name);
+    void update(sf::Time dt);
+
+    void setPosition(const sf::Vector2f& pos);
+    sf::Vector2f getPosition() const { return m_sprite.getPosition(); }
+    void setScale(const sf::Vector2f& scale) { m_sprite.setScale(scale); }
+
+    bool isFinished() const { return m_finished; }
+
+private:
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+
+    const sf::Texture& m_texture;
+    sf::Sprite m_sprite;
+    std::unordered_map<std::string, Animation> m_anims;
+    const Animation* m_current{nullptr};
+    std::size_t m_index{0};
+    sf::Time m_elapsed{};
+    bool m_finished{true};
+};
+

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -555,6 +555,7 @@ namespace FishGame
         {
         case 0:
             hazard = std::make_unique<Bomb>();
+            static_cast<Bomb*>(hazard.get())->initializeSprite(getGame().getSpriteManager());
             break;
         case 1:
             hazard = std::make_unique<Jellyfish>();

--- a/src/Utils/AnimatedSprite.cpp
+++ b/src/Utils/AnimatedSprite.cpp
@@ -1,0 +1,62 @@
+#include "Utils/AnimatedSprite.h"
+
+AnimatedSprite::AnimatedSprite(const sf::Texture& texture)
+    : m_texture(texture)
+{
+    m_sprite.setTexture(texture);
+}
+
+void AnimatedSprite::addAnimation(const std::string& name, const Animation& anim)
+{
+    m_anims[name] = anim;
+}
+
+void AnimatedSprite::play(const std::string& name)
+{
+    auto it = m_anims.find(name);
+    if (it == m_anims.end())
+        return;
+
+    m_current = &it->second;
+    m_index = 0;
+    m_elapsed = sf::Time::Zero;
+    m_finished = false;
+    m_sprite.setTextureRect(m_current->frames[0]);
+    auto bounds = m_sprite.getLocalBounds();
+    m_sprite.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+}
+
+void AnimatedSprite::update(sf::Time dt)
+{
+    if (!m_current || m_finished)
+        return;
+
+    m_elapsed += dt;
+    if (m_elapsed >= m_current->frameTime)
+    {
+        m_elapsed -= m_current->frameTime;
+        ++m_index;
+        if (m_index >= m_current->frames.size())
+        {
+            if (m_current->loop)
+                m_index = 0;
+            else
+            {
+                m_index = m_current->frames.size() - 1;
+                m_finished = true;
+            }
+        }
+        m_sprite.setTextureRect(m_current->frames[m_index]);
+    }
+}
+
+void AnimatedSprite::setPosition(const sf::Vector2f& pos)
+{
+    m_sprite.setPosition(pos);
+}
+
+void AnimatedSprite::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    target.draw(m_sprite, states);
+}
+


### PR DESCRIPTION
## Summary
- implement new AnimatedSprite helper
- rework Bomb hazard to use Bomb.png sprite sheet
- load Bomb sprite animations and handle state transitions
- spawn bombs with sprites in PlayState

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6856bae57e24833398e84f66b378cda2