### PR TITLE
Fix bomb animation loop

### DIFF
--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -59,6 +59,7 @@ namespace FishGame
             {87, 216, 86, 84}
         };
         puffs.frameTime = sf::seconds(m_puffFrameTime);
+        puffs.loop = false;
 
         AnimatedSprite::Animation smoke;
         smoke.frames.push_back(sf::IntRect(1, 300, 122, 121));


### PR DESCRIPTION
## Summary
- correct bomb 'puffs' animation to run once so state advances

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6856be107db08333b646999eff7d7f66