### PR TITLE
Improve bomb animation smoothing

### DIFF
--- a/include/Entities/Hazard.h
+++ b/include/Entities/Hazard.h
@@ -75,6 +75,7 @@ namespace FishGame
         float m_explosionRadius;
 
         static constexpr float m_baseRadius = 20.0f;
+        static constexpr float m_maxExplosionRadius = 100.0f;
         static constexpr float m_explosionDuration = 0.4f; // 5 frames * 0.08s
         static constexpr int m_maxPuffLoops = 3;
         static constexpr float m_puffFrameTime = 0.1f;

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -89,11 +89,16 @@ namespace FishGame
         case State::IdleBomb:
             break;
         case State::Explode:
-            m_explosionRadius = 100.f;
-            m_isExploding = m_stateTimer.asSeconds() <= m_explosionDuration;
+        {
+            float progress = m_stateTimer.asSeconds() / m_explosionDuration;
+            progress = std::clamp(progress, 0.f, 1.f);
+            m_explosionRadius = m_baseRadius +
+                (m_maxExplosionRadius - m_baseRadius) * progress;
+            m_isExploding = progress < 1.f;
             if (m_sprite->isFinished())
                 advanceState();
             break;
+        }
         case State::Puffs:
             if (m_sprite->isFinished())
             {


### PR DESCRIPTION
## Summary
- add max explosion radius constant for bombs
- interpolate bomb explosion radius over time for smoother animation

## Testing
- `apt-get install -y libsfml-dev` *(to satisfy build requirements)*
- `cmake -B build` *(fails: could not find sfml-main or openal DLLs)*

------
https://chatgpt.com/codex/tasks/task_e_6856c033da988333b8ee5d6cf9eeb5d7