### PR TITLE
Add templated Level and between-level preview

### DIFF
--- a/docs/LevelConfig.md
+++ b/docs/LevelConfig.md
@@ -1,0 +1,22 @@
+# Level Configuration
+
+Levels describe which enemies and power-ups appear when a stage begins. The
+`Level` template stores collections of `Entity` objects and can be loaded using a
+simple `LevelConfig` structure:
+
+```cpp
+struct LevelConfig {
+    std::vector<sf::Vector2f> enemyPositions;   // where enemies spawn
+    std::vector<sf::Vector2f> powerUpPositions; // where power-ups appear
+};
+```
+
+```cpp
+Level<SmallFish, ExtraLifePowerUp> level;
+LevelConfig config;
+config.enemyPositions.push_back({100.f, 100.f});
+config.powerUpPositions.push_back({200.f, 200.f});
+level.load(config);
+```
+
+Each level is complete when all enemies and power-ups have been cleared.

--- a/include/Core/State.h
+++ b/include/Core/State.h
@@ -20,7 +20,8 @@ namespace FishGame
         Pause,
         GameOver,
 		GameOptions,
-        BonusStage
+        BonusStage,
+        BetweenLevel
     };
 
     // State stack actions

--- a/include/Levels/Level.h
+++ b/include/Levels/Level.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "Entity.h"
+#include <SFML/System.hpp>
+#include <memory>
+#include <vector>
+#include <type_traits>
+
+namespace FishGame
+{
+    struct LevelConfig
+    {
+        std::vector<sf::Vector2f> enemyPositions;
+        std::vector<sf::Vector2f> powerUpPositions;
+    };
+
+    template<typename EnemyT, typename PowerUpT>
+    class Level
+    {
+        static_assert(std::is_base_of_v<Entity, EnemyT>, "EnemyT must derive from Entity");
+        static_assert(std::is_base_of_v<Entity, PowerUpT>, "PowerUpT must derive from Entity");
+
+    public:
+        Level() = default;
+        ~Level() = default;
+
+        void load(const LevelConfig& config);
+        bool isComplete() const;
+
+        std::vector<std::unique_ptr<Entity>>& getEnemies() { return m_enemies; }
+        std::vector<std::unique_ptr<Entity>>& getPowerUps() { return m_powerUps; }
+
+    private:
+        std::vector<std::unique_ptr<Entity>> m_enemies;
+        std::vector<std::unique_ptr<Entity>> m_powerUps;
+    };
+
+    template<typename EnemyT, typename PowerUpT>
+    void Level<EnemyT, PowerUpT>::load(const LevelConfig& config)
+    {
+        m_enemies.clear();
+        m_powerUps.clear();
+
+        for (const auto& pos : config.enemyPositions)
+        {
+            auto enemy = std::make_unique<EnemyT>();
+            enemy->setPosition(pos);
+            m_enemies.push_back(std::move(enemy));
+        }
+
+        for (const auto& pos : config.powerUpPositions)
+        {
+            auto power = std::make_unique<PowerUpT>();
+            power->setPosition(pos);
+            m_powerUps.push_back(std::move(power));
+        }
+    }
+
+    template<typename EnemyT, typename PowerUpT>
+    bool Level<EnemyT, PowerUpT>::isComplete() const
+    {
+        auto alive = [](const auto& e) { return e && e->isAlive(); };
+        bool enemiesGone = std::none_of(m_enemies.begin(), m_enemies.end(), alive);
+        bool powerUpsGone = std::none_of(m_powerUps.begin(), m_powerUps.end(), alive);
+        return enemiesGone && powerUpsGone;
+    }
+}
+

--- a/include/States/BetweenLevelState.h
+++ b/include/States/BetweenLevelState.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "State.h"
+#include "GameConstants.h"
+#include <vector>
+#include <string>
+
+namespace FishGame
+{
+    void setBetweenLevelEntities(std::vector<std::string> entities);
+
+    class BetweenLevelState : public State
+    {
+    public:
+        explicit BetweenLevelState(Game& game);
+        ~BetweenLevelState() override = default;
+
+        void handleEvent(const sf::Event& event) override;
+        bool update(sf::Time deltaTime) override;
+        void render() override;
+        void onActivate() override;
+
+    private:
+        std::vector<std::string> m_entities;
+        sf::Text m_headerText;
+        sf::Text m_continueText;
+        std::vector<sf::Text> m_entityTexts;
+        sf::RectangleShape m_background;
+    };
+}
+

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -3,6 +3,7 @@
 #include "IntroState.h"
 #include "MenuState.h"
 #include "PlayState.h"
+#include "BetweenLevelState.h"
 #include "GameOverState.h"
 #include "PauseState.h"
 #include "GameOptionsState.h"
@@ -226,6 +227,7 @@ namespace FishGame
         registerState<IntroState>(StateID::Intro);
         registerState<MenuState>(StateID::Menu);
         registerState<PlayState>(StateID::Play);
+        registerState<BetweenLevelState>(StateID::BetweenLevel);
         // Register bonus stage
         m_stateFactories[StateID::BonusStage] = [this]() -> std::unique_ptr<State>
             {

--- a/src/Levels/Level.cpp
+++ b/src/Levels/Level.cpp
@@ -1,0 +1,6 @@
+#include "Levels/Level.h"
+
+namespace FishGame
+{
+    // Explicit template instantiation for common enemy/power-up types can be added here if needed.
+}

--- a/src/States/BetweenLevelState.cpp
+++ b/src/States/BetweenLevelState.cpp
@@ -1,0 +1,100 @@
+#include "BetweenLevelState.h"
+#include "Game.h"
+
+namespace FishGame
+{
+    namespace
+    {
+        std::vector<std::string> g_upcomingEntities;
+    }
+
+    void setBetweenLevelEntities(std::vector<std::string> entities)
+    {
+        g_upcomingEntities = std::move(entities);
+    }
+
+    static std::vector<std::string> takeEntities()
+    {
+        std::vector<std::string> tmp;
+        tmp.swap(g_upcomingEntities);
+        return tmp;
+    }
+
+    BetweenLevelState::BetweenLevelState(Game& game)
+        : State(game)
+        , m_entities(takeEntities())
+        , m_headerText()
+        , m_continueText()
+        , m_entityTexts()
+        , m_background()
+    {
+    }
+
+    void BetweenLevelState::onActivate()
+    {
+        auto& window = getGame().getWindow();
+        auto& font = getGame().getFonts().get(Fonts::Main);
+
+        m_background.setSize(sf::Vector2f(window.getSize()));
+        m_background.setFillColor(Constants::OVERLAY_COLOR);
+
+        m_headerText.setFont(font);
+        m_headerText.setString("Upcoming Creatures");
+        m_headerText.setCharacterSize(48);
+        m_headerText.setFillColor(sf::Color::White);
+        sf::FloatRect hb = m_headerText.getLocalBounds();
+        m_headerText.setOrigin(hb.width / 2.f, hb.height / 2.f);
+        m_headerText.setPosition(window.getSize().x / 2.f, 150.f);
+
+        m_continueText.setFont(font);
+        m_continueText.setString("Press Enter to start");
+        m_continueText.setCharacterSize(32);
+        m_continueText.setFillColor(sf::Color::White);
+        sf::FloatRect cb = m_continueText.getLocalBounds();
+        m_continueText.setOrigin(cb.width / 2.f, cb.height / 2.f);
+        m_continueText.setPosition(window.getSize().x / 2.f, window.getSize().y - 150.f);
+
+        float y = 250.f;
+        for (const auto& name : m_entities)
+        {
+            sf::Text text;
+            text.setFont(font);
+            text.setString(name);
+            text.setCharacterSize(32);
+            text.setFillColor(sf::Color::Yellow);
+            sf::FloatRect tb = text.getLocalBounds();
+            text.setOrigin(tb.width / 2.f, tb.height / 2.f);
+            text.setPosition(window.getSize().x / 2.f, y);
+            y += 40.f;
+            m_entityTexts.push_back(text);
+        }
+    }
+
+    void BetweenLevelState::handleEvent(const sf::Event& event)
+    {
+        if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Enter)
+        {
+            deferAction([this]() { requestStackPop(); });
+        }
+    }
+
+    bool BetweenLevelState::update(sf::Time deltaTime)
+    {
+        processDeferredActions();
+        (void)deltaTime;
+        return false;
+    }
+
+    void BetweenLevelState::render()
+    {
+        auto& window = getGame().getWindow();
+        window.draw(m_background);
+        window.draw(m_headerText);
+        for (const auto& t : m_entityTexts)
+        {
+            window.draw(t);
+        }
+        window.draw(m_continueText);
+    }
+}
+

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -1,7 +1,10 @@
 ﻿#include "PlayState.h"
 #include "Game.h"
 #include "CollisionDetector.h"
+#include "Levels/Level.h"
+#include "BetweenLevelState.h"
 #include "Fish.h"
+#include "GenericFish.h"
 #include "ExtendedPowerUps.h"
 #include "GameOverState.h"
 #include "PauseState.h"
@@ -990,6 +993,15 @@ namespace FishGame
         }
 
         m_environmentSystem->setRandomTimeOfDay();
+
+        Level<SmallFish, ExtraLifePowerUp> level;
+        LevelConfig config;
+        config.enemyPositions.push_back({ 300.f, 300.f });
+        config.powerUpPositions.push_back({ 600.f, 400.f });
+        level.load(config);
+
+        setBetweenLevelEntities({ "SmallFish", "ExtraLife" });
+        deferAction([this]() { requestStackPush(StateID::BetweenLevel); });
 
         resetLevel();
         updateLevelDifficulty();


### PR DESCRIPTION
## Summary
- introduce a templated `Level` class for enemies and power‑ups
- add `BetweenLevelState` to preview new entities
- register and use the new state from `PlayState`
- document the simple level configuration format

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*


------
https://chatgpt.com/codex/tasks/task_e_685824a445ec8333b2827765e502b9bd