### PR TITLE
Implement behavior-based fish entity

### DIFF
--- a/include/Entities/BehaviorFish.h
+++ b/include/Entities/BehaviorFish.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "Entity.h"
+#include "SpriteComponent.h"
+#include <utility>
+
+namespace FishGame {
+    // Base behavior interface
+    struct IFishBehavior {
+        virtual ~IFishBehavior() = default;
+        virtual void update(Entity& self, sf::Time dt) = 0;
+    };
+
+    // Template-based fish entity using a behavior strategy
+    template<class Behavior>
+    class BehaviorFish : public Entity {
+    public:
+        explicit BehaviorFish(Behavior behavior)
+            : m_behavior(std::move(behavior)) {}
+
+        void update(sf::Time dt) override {
+            m_behavior.update(*this, dt);
+        }
+
+        sf::FloatRect getBounds() const override {
+            if (auto sprite = getSpriteComponent())
+                return sprite->getBounds();
+            return sf::FloatRect();
+        }
+
+        EntityType getType() const override { return EntityType::SmallFish; }
+
+    private:
+        Behavior m_behavior;
+    };
+
+    // Example behaviors
+    struct PassiveBehavior : IFishBehavior {
+        void update(Entity& self, sf::Time dt) override {
+            // simple idle swim behaviour
+            sf::Vector2f pos = self.getPosition();
+            pos.x += 10.f * dt.asSeconds();
+            self.setPosition(pos);
+        }
+    };
+
+    struct AggressiveBehavior : IFishBehavior {
+        void update(Entity& self, sf::Time dt) override {
+            // move faster toward the right
+            sf::Vector2f pos = self.getPosition();
+            pos.x += 50.f * dt.asSeconds();
+            self.setPosition(pos);
+        }
+    };
+}

--- a/include/Managers/EntityRegistry.h
+++ b/include/Managers/EntityRegistry.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Entity.h"
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace FishGame {
+    // Simple runtime entity factory registry
+    class EntityRegistry {
+    public:
+        template<typename T>
+        void registerType(const std::string& name) {
+            static_assert(std::is_base_of_v<Entity, T>, "T must derive from Entity");
+            m_factories[name] = [] { return std::make_unique<T>(); };
+        }
+
+        std::unique_ptr<Entity> create(const std::string& name) const {
+            auto it = m_factories.find(name);
+            if (it != m_factories.end())
+                return it->second();
+            return nullptr;
+        }
+
+    private:
+        std::unordered_map<std::string, std::function<std::unique_ptr<Entity>()>> m_factories;
+    };
+}


### PR DESCRIPTION
## Summary
- add BehaviorFish template for strategy-based fish behaviors
- add PassiveBehavior and AggressiveBehavior examples
- implement EntityRegistry for runtime entity creation

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68582a9489908333b19e2e1e45385747