### PR TITLE
Implement data-driven level configuration

### DIFF
--- a/include/Levels/LevelTable.h
+++ b/include/Levels/LevelTable.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace FishGame {
+
+struct EntityInfo {
+    std::string type;
+    unsigned count;
+};
+
+struct LevelDef {
+    std::vector<EntityInfo> enemies;
+    std::vector<std::string> powerUps;
+    std::string goal;
+};
+
+extern const std::unordered_map<int, LevelDef> LEVELS;
+
+} // namespace FishGame
+

--- a/src/Levels/LevelTable.cpp
+++ b/src/Levels/LevelTable.cpp
@@ -1,0 +1,18 @@
+#include "Levels/LevelTable.h"
+
+namespace FishGame {
+
+const std::unordered_map<int, LevelDef> LEVELS = {
+    {1, { { {"Fish",3} }, {"Life","Star"}, "Survive" }},
+    {2, { { {"Fish",3},{"Oyster",1} }, {"Speed","x2","Frenzy","Freeze"}, "Survive"}},
+    {3, { { {"Fish",3},{"PoisonFish",1},{"AngelFish",1} }, {}, "Survive"}},
+    {100, { { {"Oyster",3} }, {"Add-Time"}, "Eat oysters"}},
+    {4, { { {"Fish",3},{"Jellyfish",1},{"Pufferfish",1} }, {}, "Survive"}},
+    {5, { { {"Fish",3},{"Barracuda",1} }, {}, "Survive"}},
+    {6, { { {"Fish",3},{"Bomb",2} }, {}, "Survive"}},
+    {200, { { {"SmallFish",5} }, {}, "Eat small fish & avoid bombs"}},
+    {7, { { {"All",10} }, {}, "Final challenge"}}
+};
+
+} // namespace FishGame
+

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -2,6 +2,7 @@
 #include "Game.h"
 #include "CollisionDetector.h"
 #include "Levels/Level.h"
+#include "Levels/LevelTable.h"
 #include "BetweenLevelState.h"
 #include "Fish.h"
 #include "GenericFish.h"
@@ -994,19 +995,29 @@ namespace FishGame
 
         m_environmentSystem->setRandomTimeOfDay();
 
-        Level<SmallFish, ExtraLifePowerUp> level;
-        LevelConfig config;
-        config.enemyPositions.push_back({ 300.f, 300.f });
-        config.powerUpPositions.push_back({ 600.f, 400.f });
-        level.load(config);
+        std::vector<std::string> upcoming;
+        if (auto it = LEVELS.find(m_gameState.currentLevel); it != LEVELS.end())
+        {
+            const LevelDef& def = it->second;
+            for (const auto& e : def.enemies)
+                upcoming.push_back(e.type);
+            upcoming.insert(upcoming.end(), def.powerUps.begin(), def.powerUps.end());
+            m_hud.messageText.setString(def.goal);
+        }
+        else
+        {
+            m_hud.messageText.setString("");
+        }
 
-        setBetweenLevelEntities({ "SmallFish", "ExtraLife" });
-        deferAction([this]() { requestStackPush(StateID::BetweenLevel); });
+        if (!upcoming.empty())
+        {
+            setBetweenLevelEntities(upcoming);
+            deferAction([this]() { requestStackPush(StateID::BetweenLevel); });
+        }
 
         resetLevel();
         updateLevelDifficulty();
 
-        m_hud.messageText.setString("");
         m_bonusStageTriggered = false;
     }
 


### PR DESCRIPTION
## Summary
- add `LevelTable` with `EntityInfo`, `LevelDef`, and level data
- include level table in `PlayState`
- load next level info from the table

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68582c07327883339b68824e9de366a2