### PR TITLE
Implement BetweenLevelState using LevelDef

### DIFF
--- a/include/States/BetweenLevelState.h
+++ b/include/States/BetweenLevelState.h
@@ -2,17 +2,20 @@
 
 #include "State.h"
 #include "GameConstants.h"
+#include "Levels/LevelTable.h"
 #include <vector>
 #include <string>
 
 namespace FishGame
 {
-    void setBetweenLevelEntities(std::vector<std::string> entities);
+    // Store the definition for the upcoming level so the state can access it
+    void setUpcomingLevelDef(LevelDef def);
+    LevelDef takeUpcomingLevelDef();
 
     class BetweenLevelState : public State
     {
     public:
-        explicit BetweenLevelState(Game& game);
+        explicit BetweenLevelState(Game& game, LevelDef upcoming);
         ~BetweenLevelState() override = default;
 
         void handleEvent(const sf::Event& event) override;
@@ -21,7 +24,7 @@ namespace FishGame
         void onActivate() override;
 
     private:
-        std::vector<std::string> m_entities;
+        LevelDef m_def;
         sf::Text m_headerText;
         sf::Text m_continueText;
         std::vector<sf::Text> m_entityTexts;

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -227,7 +227,10 @@ namespace FishGame
         registerState<IntroState>(StateID::Intro);
         registerState<MenuState>(StateID::Menu);
         registerState<PlayState>(StateID::Play);
-        registerState<BetweenLevelState>(StateID::BetweenLevel);
+        m_stateFactories[StateID::BetweenLevel] = [this]() -> std::unique_ptr<State>
+            {
+                return std::make_unique<BetweenLevelState>(*this, takeUpcomingLevelDef());
+            };
         // Register bonus stage
         m_stateFactories[StateID::BonusStage] = [this]() -> std::unique_ptr<State>
             {

--- a/src/States/BetweenLevelState.cpp
+++ b/src/States/BetweenLevelState.cpp
@@ -1,28 +1,30 @@
 #include "BetweenLevelState.h"
 #include "Game.h"
+#include "Levels/LevelTable.h"
 
 namespace FishGame
 {
     namespace
     {
-        std::vector<std::string> g_upcomingEntities;
+        LevelDef g_upcomingDef;
     }
 
-    void setBetweenLevelEntities(std::vector<std::string> entities)
+    void setUpcomingLevelDef(LevelDef def)
     {
-        g_upcomingEntities = std::move(entities);
+        g_upcomingDef = std::move(def);
     }
 
-    static std::vector<std::string> takeEntities()
+    LevelDef takeUpcomingLevelDef()
     {
-        std::vector<std::string> tmp;
-        tmp.swap(g_upcomingEntities);
+        LevelDef tmp;
+        tmp = std::move(g_upcomingDef);
+        g_upcomingDef = LevelDef{};
         return tmp;
     }
 
-    BetweenLevelState::BetweenLevelState(Game& game)
+    BetweenLevelState::BetweenLevelState(Game& game, LevelDef upcoming)
         : State(game)
-        , m_entities(takeEntities())
+        , m_def(std::move(upcoming))
         , m_headerText()
         , m_continueText()
         , m_entityTexts()
@@ -55,13 +57,27 @@ namespace FishGame
         m_continueText.setPosition(window.getSize().x / 2.f, window.getSize().y - 150.f);
 
         float y = 250.f;
-        for (const auto& name : m_entities)
+        for (const auto& info : m_def.enemies)
+        {
+            sf::Text text;
+            text.setFont(font);
+            text.setString(info.type + " x" + std::to_string(info.count));
+            text.setCharacterSize(32);
+            text.setFillColor(sf::Color::Yellow);
+            sf::FloatRect tb = text.getLocalBounds();
+            text.setOrigin(tb.width / 2.f, tb.height / 2.f);
+            text.setPosition(window.getSize().x / 2.f, y);
+            y += 40.f;
+            m_entityTexts.push_back(text);
+        }
+
+        for (const auto& name : m_def.powerUps)
         {
             sf::Text text;
             text.setFont(font);
             text.setString(name);
             text.setCharacterSize(32);
-            text.setFillColor(sf::Color::Yellow);
+            text.setFillColor(sf::Color::Cyan);
             sf::FloatRect tb = text.getLocalBounds();
             text.setOrigin(tb.width / 2.f, tb.height / 2.f);
             text.setPosition(window.getSize().x / 2.f, y);

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -995,24 +995,19 @@ namespace FishGame
 
         m_environmentSystem->setRandomTimeOfDay();
 
-        std::vector<std::string> upcoming;
         if (auto it = LEVELS.find(m_gameState.currentLevel); it != LEVELS.end())
         {
             const LevelDef& def = it->second;
-            for (const auto& e : def.enemies)
-                upcoming.push_back(e.type);
-            upcoming.insert(upcoming.end(), def.powerUps.begin(), def.powerUps.end());
             m_hud.messageText.setString(def.goal);
+            if (!def.enemies.empty() || !def.powerUps.empty())
+            {
+                setUpcomingLevelDef(def);
+                deferAction([this]() { requestStackPush(StateID::BetweenLevel); });
+            }
         }
         else
         {
             m_hud.messageText.setString("");
-        }
-
-        if (!upcoming.empty())
-        {
-            setBetweenLevelEntities(upcoming);
-            deferAction([this]() { requestStackPush(StateID::BetweenLevel); });
         }
 
         resetLevel();


### PR DESCRIPTION
## Summary
- allow passing LevelDef to `BetweenLevelState`
- store upcoming level definition globally and access when creating the state
- update state implementation to list enemies and powerups from `LevelDef`
- push between-level state after advancing level

## Testing
- `cmake -B build -S .` *(fails: could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_68582d4c062483339577027d4e845151