### PR TITLE
Implement level-specific entity spawns

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <random>
 #include <unordered_map>
+#include <unordered_set>
 #include <optional>
 #include <algorithm>
 #include <numeric>
@@ -232,6 +233,11 @@ namespace FishGame
         std::uniform_int_distribution<int> m_powerUpTypeDist;
 
         bool m_initialized;
+
+        // Allowed entity types for the current level
+        std::unordered_set<std::string> m_allowedFishTypes;
+        std::unordered_set<std::string> m_allowedHazardTypes;
+        std::unordered_set<std::string> m_allowedPowerUpTypes;
 
         // Constants
         static constexpr float m_hazardSpawnInterval = 8.0f;


### PR DESCRIPTION
## Summary
- track allowed fish, hazards and power-ups for each level
- filter spawned fish, hazards and power-ups based on level definitions

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_685830e85320833391459003a7588225