### PR TITLE
Render level-specific entities

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -120,6 +120,9 @@ namespace FishGame
         void spawnRandomHazard();
         void spawnRandomPowerUp();
         sf::Vector2f generateRandomPosition();
+        void spawnLevelEntities();
+        std::unique_ptr<Entity> createEntityFromName(const std::string& type);
+        std::unique_ptr<PowerUp> createPowerUpFromName(const std::string& name);
 
         // Effect helpers
         void createParticleEffect(const sf::Vector2f& position, const sf::Color& color,


### PR DESCRIPTION
## Summary
- add helper methods to spawn entities from `LevelTable`
- construct level enemies and power-ups on reset

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685836572c6c8333b31260df9834f58f