### PR TITLE
Fix PlayState window bounds argument

### DIFF
--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -788,7 +788,14 @@ namespace FishGame
                     {
                         bool fromLeft = m_randomEngine() % 2 == 0;
                         fish->setDirection(fromLeft ? 1.f : -1.f, 0.f);
-                        fish->setWindowBounds(m_worldSize);
+                        // m_worldSize stores floating point dimensions of the
+                        // game world which originate from the window size.
+                        // Fish::setWindowBounds however expects an unsigned
+                        // integer vector (sf::Vector2u). Convert the value to
+                        // avoid the implicit sf::Vector2f -> sf::Vector2u
+                        // conversion error that caused a build failure on
+                        // MSVC.
+                        fish->setWindowBounds(static_cast<sf::Vector2u>(m_worldSize));
                         fish->initializeSprite(getGame().getSpriteManager());
                         m_entities.push_back(std::move(entity));
                     }


### PR DESCRIPTION
## Summary
- fix call to `setWindowBounds` in PlayState by converting to `sf::Vector2u`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6858394da3888333a2ec64bf00820034