### PR TITLE
Display upcoming level sprites

### DIFF
--- a/include/States/BetweenLevelState.h
+++ b/include/States/BetweenLevelState.h
@@ -27,7 +27,14 @@ namespace FishGame
         LevelDef m_def;
         sf::Text m_headerText;
         sf::Text m_continueText;
-        std::vector<sf::Text> m_entityTexts;
+        struct DisplayItem
+        {
+            sf::Sprite sprite;
+            sf::Text text;
+            bool hasSprite{false};
+        };
+
+        std::vector<DisplayItem> m_items;
         sf::RectangleShape m_background;
     };
 }


### PR DESCRIPTION
## Summary
- add sprite display vector for upcoming level preview
- load textures for level preview items
- render sprites and text in `BetweenLevelState`

## Testing
- `cmake -B build -S .` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68583b0db2488333b46f9d237b987fa8