### PR TITLE
Gate freeze and speed power-ups until level two

### DIFF
--- a/src/Managers/BonusItemManager.cpp
+++ b/src/Managers/BonusItemManager.cpp
@@ -141,7 +141,14 @@ namespace FishGame
     std::unique_ptr<PowerUp> BonusItemManager::createRandomPowerUp()
     {
         // Extended to include new power-ups
-        int type = std::uniform_int_distribution<int>(0, 4)(m_randomEngine);
+        std::vector<int> types;
+        if (m_currentLevel >= 2)
+            types = {0, 1, 2, 3, 4};
+        else
+            types = {0, 1, 3}; // Freeze and SpeedBoost unlocked from level 2
+
+        int index = std::uniform_int_distribution<int>(0, static_cast<int>(types.size()) - 1)(m_randomEngine);
+        int type = types[index];
 
         switch (type)
         {

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -575,7 +575,11 @@ namespace FishGame
     {
         std::unique_ptr<PowerUp> powerUp;
 
-        switch (m_powerUpTypeDist(m_randomEngine))
+        int type = m_powerUpTypeDist(m_randomEngine);
+        if (m_gameState.currentLevel < 2 && (type == 0 || type == 2))
+            type = 1; // Freeze and SpeedBoost unlocked from level 2
+
+        switch (type)
         {
         case 0:
             powerUp = std::make_unique<FreezePowerUp>();


### PR DESCRIPTION
## Summary
- delay SpeedBoost and Freeze power-ups until the player reaches level 2
- ensure BonusItemManager doesn't create these power-ups before level 2

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6858668e662c83338649ad8c5280be2b