### PR TITLE
Delay special fish until level 3

### DIFF
--- a/src/Managers/EnhancedFishSpawner.cpp
+++ b/src/Managers/EnhancedFishSpawner.cpp
@@ -45,8 +45,13 @@ namespace FishGame
             // Spawn special fish types
             spawnSpecialFish<Barracuda>(m_specialConfig.barracudaSpawnRate, deltaTime);
             spawnSpecialFish<Pufferfish>(m_specialConfig.pufferfishSpawnRate, deltaTime);
-            spawnSpecialFish<Angelfish>(m_specialConfig.angelfishSpawnRate, deltaTime);
-            spawnSpecialFish<PoisonFish>(m_specialConfig.poisonFishSpawnRate, deltaTime);
+
+            // Angelfish and PoisonFish only appear starting from level 3
+            if (currentLevel >= 3)
+            {
+                spawnSpecialFish<Angelfish>(m_specialConfig.angelfishSpawnRate, deltaTime);
+                spawnSpecialFish<PoisonFish>(m_specialConfig.poisonFishSpawnRate, deltaTime);
+            }
         }
 
         // Check for school spawning - ONLY FOR SMALL FISH


### PR DESCRIPTION
## Summary
- adjust special fish spawner so angelfish and poisonfish spawn starting at level 3

## Testing
- `cmake -S . -B build` *(fails: could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_685868b730008333ab9a573cb97ee4dd