### PR TITLE
Adjust spawn levels for hazards and special fish

### DIFF
--- a/src/Managers/EnhancedFishSpawner.cpp
+++ b/src/Managers/EnhancedFishSpawner.cpp
@@ -33,25 +33,30 @@ namespace FishGame
         FishSpawner::update(deltaTime, currentLevel);
 
         // Update special fish spawning
-        if (currentLevel >= 2)  // Special fish start appearing from level 2
-        {
-            // Update spawn timers
-            std::for_each(m_specialSpawnTimers.begin(), m_specialSpawnTimers.end(),
-                [deltaTime](auto& pair)
-                {
-                    pair.second += deltaTime;
-                });
-
-            // Spawn special fish types
-            spawnSpecialFish<Barracuda>(m_specialConfig.barracudaSpawnRate, deltaTime);
-            spawnSpecialFish<Pufferfish>(m_specialConfig.pufferfishSpawnRate, deltaTime);
-
-            // Angelfish and PoisonFish only appear starting from level 3
-            if (currentLevel >= 3)
+        // Timers are updated regardless of level
+        std::for_each(m_specialSpawnTimers.begin(), m_specialSpawnTimers.end(),
+            [deltaTime](auto& pair)
             {
-                spawnSpecialFish<Angelfish>(m_specialConfig.angelfishSpawnRate, deltaTime);
-                spawnSpecialFish<PoisonFish>(m_specialConfig.poisonFishSpawnRate, deltaTime);
-            }
+                pair.second += deltaTime;
+            });
+
+        // Barracuda appear from level 6 onwards
+        if (currentLevel >= 6)
+        {
+            spawnSpecialFish<Barracuda>(m_specialConfig.barracudaSpawnRate, deltaTime);
+        }
+
+        // Pufferfish appear from level 4 onwards
+        if (currentLevel >= 4)
+        {
+            spawnSpecialFish<Pufferfish>(m_specialConfig.pufferfishSpawnRate, deltaTime);
+        }
+
+        // Angelfish and PoisonFish retain their level 3 requirement
+        if (currentLevel >= 3)
+        {
+            spawnSpecialFish<Angelfish>(m_specialConfig.angelfishSpawnRate, deltaTime);
+            spawnSpecialFish<PoisonFish>(m_specialConfig.poisonFishSpawnRate, deltaTime);
         }
 
         // Check for school spawning - ONLY FOR SMALL FISH

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -554,13 +554,19 @@ namespace FishGame
         switch (m_hazardTypeDist(m_randomEngine))
         {
         case 0:
-            hazard = std::make_unique<Bomb>();
-            static_cast<Bomb*>(hazard.get())->initializeSprite(getGame().getSpriteManager());
+            if (m_gameState.currentLevel >= 6)
+            {
+                hazard = std::make_unique<Bomb>();
+                static_cast<Bomb*>(hazard.get())->initializeSprite(getGame().getSpriteManager());
+            }
             break;
         case 1:
-            hazard = std::make_unique<Jellyfish>();
-            static_cast<Jellyfish*>(hazard.get())->initializeSprite(getGame().getSpriteManager());
-            hazard->setVelocity(0.0f, 20.0f);
+            if (m_gameState.currentLevel >= 4)
+            {
+                hazard = std::make_unique<Jellyfish>();
+                static_cast<Jellyfish*>(hazard.get())->initializeSprite(getGame().getSpriteManager());
+                hazard->setVelocity(0.0f, 20.0f);
+            }
             break;
         }
 


### PR DESCRIPTION
## Summary
- adjust spawning logic so Barracuda appear from level 6
- require level 4 before Pufferfish are spawned
- spawn bombs only from level 6
- spawn jellyfish from level 4

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68586d35035083339f5cefb0ed2acd06