### PR TITLE
Implement movement strategies for fish

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -2,6 +2,7 @@
 
 #include "Entity.h"
 #include "Animator.h"
+#include "MovementStrategy.h"
 #include <vector>
 #include <memory>
 #include <string>
@@ -55,6 +56,11 @@ namespace FishGame
         float getSpeed() const { return m_speed; }
         int getCurrentLevel() const { return m_currentLevel; }
         sf::Vector2u getWindowBounds() const { return m_windowBounds; }
+
+        void setMovementStrategy(std::unique_ptr<MovementStrategy> strategy)
+        {
+            m_movementStrategy = std::move(strategy);
+        }
 
         // Virtual methods for derived classes
         virtual int getPointValue() const { return m_pointValue; }
@@ -134,5 +140,7 @@ namespace FishGame
         bool m_eating{ false };
         sf::Time m_eatTimer{ sf::Time::Zero };
         static constexpr float m_eatDuration = 0.5f;
+
+        std::unique_ptr<MovementStrategy> m_movementStrategy;
     };
 }

--- a/include/Systems/AggressiveChaseStrategy.h
+++ b/include/Systems/AggressiveChaseStrategy.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "MovementStrategy.h"
+
+namespace FishGame
+{
+    class AggressiveChaseStrategy : public MovementStrategy
+    {
+    public:
+        AggressiveChaseStrategy(Entity* target);
+        void update(Entity& entity, sf::Time deltaTime) override;
+
+    private:
+        Entity* m_target;
+    };
+}
+

--- a/include/Systems/MovementStrategy.h
+++ b/include/Systems/MovementStrategy.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Entity.h"
+#include <SFML/System/Time.hpp>
+
+namespace FishGame
+{
+    class MovementStrategy
+    {
+    public:
+        virtual ~MovementStrategy() = default;
+        virtual void update(Entity& entity, sf::Time deltaTime) = 0;
+    };
+}
+

--- a/include/Systems/RandomWanderStrategy.h
+++ b/include/Systems/RandomWanderStrategy.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "MovementStrategy.h"
+#include <random>
+
+namespace FishGame
+{
+    class RandomWanderStrategy : public MovementStrategy
+    {
+    public:
+        RandomWanderStrategy();
+        void update(Entity& entity, sf::Time deltaTime) override;
+
+    private:
+        sf::Time m_changeTimer;
+        std::default_random_engine m_engine;
+    };
+}
+

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -5,6 +5,7 @@
 #include "GameConstants.h"
 #include "Player.h"
 #include "SpecialFish.h"
+#include "MovementStrategy.h"
 #include <cmath>
 #include <algorithm>
 
@@ -32,6 +33,7 @@ namespace FishGame
         , m_baseColor(sf::Color::White)
         , m_eating(false)
         , m_eatTimer(sf::Time::Zero)
+        , m_movementStrategy(nullptr)
     {
         // Set radius based on size
         switch (m_size)
@@ -549,7 +551,14 @@ namespace FishGame
 
     void Fish::updateMovement(sf::Time deltaTime)
     {
-        m_position += m_velocity * deltaTime.asSeconds();
+        if (m_movementStrategy)
+        {
+            m_movementStrategy->update(*this, deltaTime);
+        }
+        else
+        {
+            m_position += m_velocity * deltaTime.asSeconds();
+        }
     }
 
     int Fish::getPointValue(FishSize size, int level)

--- a/src/Managers/FishSpawner.cpp
+++ b/src/Managers/FishSpawner.cpp
@@ -1,6 +1,8 @@
 #include "FishSpawner.h"
 #include "GameConstants.h"
 #include "SpriteManager.h"
+#include "RandomWanderStrategy.h"
+#include "AggressiveChaseStrategy.h"
 #include <algorithm>
 #include <array>
 
@@ -87,6 +89,7 @@ namespace FishGame
             fish.setDirection(smallConfig.fromLeft ? 1.0f : -1.0f, 0.0f);
             fish.setWindowBounds(m_windowSize);
             fish.initializeSprite(*m_spriteManager);
+            fish.setMovementStrategy(std::make_unique<RandomWanderStrategy>());
             };
 
         m_smallSpawner.setConfig(smallSpawnerConfig);
@@ -109,6 +112,7 @@ namespace FishGame
             };
             std::uniform_int_distribution<int> dist(0, colors.size() - 1);
             fish.setBaseColor(colors[dist(m_randomEngine)]);
+            fish.setMovementStrategy(std::make_unique<RandomWanderStrategy>());
             };
 
         m_mediumSpawner.setConfig(mediumSpawnerConfig);
@@ -124,6 +128,7 @@ namespace FishGame
             fish.setDirection(largeConfig.fromLeft ? 1.0f : -1.0f, 0.0f);
             fish.setWindowBounds(m_windowSize);
             fish.initializeSprite(*m_spriteManager);
+            fish.setMovementStrategy(std::make_unique<AggressiveChaseStrategy>(nullptr));
             };
 
         m_largeSpawner.setConfig(largeSpawnerConfig);

--- a/src/Systems/AggressiveChaseStrategy.cpp
+++ b/src/Systems/AggressiveChaseStrategy.cpp
@@ -1,0 +1,33 @@
+#include "AggressiveChaseStrategy.h"
+#include "Fish.h"
+#include <cmath>
+
+namespace FishGame
+{
+    AggressiveChaseStrategy::AggressiveChaseStrategy(Entity* target)
+        : m_target(target)
+    {
+    }
+
+    void AggressiveChaseStrategy::update(Entity& entity, sf::Time deltaTime)
+    {
+        if (!m_target)
+        {
+            entity.updatePosition(deltaTime);
+            return;
+        }
+
+        sf::Vector2f direction = m_target->getPosition() - entity.getPosition();
+        float length = std::sqrt(direction.x * direction.x + direction.y * direction.y);
+        if (length > 0.f)
+        {
+            direction /= length;
+        }
+        float speed = 100.f;
+        if (auto* fish = dynamic_cast<Fish*>(&entity))
+            speed = fish->getSpeed();
+        entity.setVelocity(direction * speed);
+        entity.updatePosition(deltaTime);
+    }
+}
+

--- a/src/Systems/RandomWanderStrategy.cpp
+++ b/src/Systems/RandomWanderStrategy.cpp
@@ -1,0 +1,29 @@
+#include "RandomWanderStrategy.h"
+#include "Fish.h"
+#include <cmath>
+
+namespace FishGame
+{
+    RandomWanderStrategy::RandomWanderStrategy()
+        : m_changeTimer(sf::seconds(0.f))
+        , m_engine(std::random_device{}())
+    {
+    }
+
+    void RandomWanderStrategy::update(Entity& entity, sf::Time deltaTime)
+    {
+        m_changeTimer -= deltaTime;
+        if (m_changeTimer <= sf::Time::Zero)
+        {
+            std::uniform_real_distribution<float> angleDist(0.f, 2.f * 3.14159265f);
+            float angle = angleDist(m_engine);
+            float speed = 100.f;
+            if (auto* fish = dynamic_cast<Fish*>(&entity))
+                speed = fish->getSpeed();
+            entity.setVelocity(std::cos(angle) * speed, std::sin(angle) * speed);
+            m_changeTimer = sf::seconds(1.f);
+        }
+        entity.updatePosition(deltaTime);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add generic `MovementStrategy` interface
- update `Fish` to delegate to optional strategy
- provide `RandomWanderStrategy` and `AggressiveChaseStrategy`
- assign strategies during fish creation via `FishSpawner`

## Testing
- `cmake -B build -S .` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68595137f34c83339516c136093be613