### PR TITLE
Remove unused SpriteComponent methods

### DIFF
--- a/include/Systems/SpriteComponent.h
+++ b/include/Systems/SpriteComponent.h
@@ -40,10 +40,7 @@ namespace FishGame
         void syncWithOwner();
 
         // Sprite manipulation
-        void setScale(float scaleX, float scaleY);
-        void setScale(const sf::Vector2f& scale);
         void setColor(const sf::Color& color);
-        void setRotation(float angle);
         void setTextureRect(const sf::IntRect& rect);
 
         // Getters
@@ -53,7 +50,6 @@ namespace FishGame
         // State effects
         void applyFlashEffect(const sf::Color& color, float intensity);
         void applyPulseEffect(float scale, float speed);
-        void resetEffects();
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;

--- a/src/Systems/SpriteComponent.cpp
+++ b/src/Systems/SpriteComponent.cpp
@@ -135,28 +135,10 @@ namespace FishGame
     }
 
     template<typename OwnerType>
-    void SpriteComponent<OwnerType>::setScale(float scaleX, float scaleY)
-    {
-        m_sprite.setScale(scaleX, scaleY);
-    }
-
-    template<typename OwnerType>
-    void SpriteComponent<OwnerType>::setScale(const sf::Vector2f& scale)
-    {
-        m_sprite.setScale(scale);
-    }
-
-    template<typename OwnerType>
     void SpriteComponent<OwnerType>::setColor(const sf::Color& color)
     {
         m_baseColor = color;
         m_sprite.setColor(color);
-    }
-
-    template<typename OwnerType>
-    void SpriteComponent<OwnerType>::setRotation(float angle)
-    {
-        m_sprite.setRotation(angle);
     }
 
     template<typename OwnerType>
@@ -187,15 +169,6 @@ namespace FishGame
         m_pulseScale = scale;
         m_pulseSpeed = speed;
         m_pulseTimer = 0.0f;
-    }
-
-    template<typename OwnerType>
-    void SpriteComponent<OwnerType>::resetEffects()
-    {
-        m_isPulsing = false;
-        m_flashIntensity = 0.0f;
-        m_sprite.setColor(m_baseColor);
-        m_sprite.setScale(m_config.scaleMultiplier, m_config.scaleMultiplier);
     }
 
     template<typename OwnerType>


### PR DESCRIPTION
## Summary
- drop unused scale, rotation, and reset functions from SpriteComponent

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6859d7ce8f9883339eb5292a0f8879e7