### PR TITLE
Remove mouse-based control

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -30,9 +30,7 @@ namespace FishGame
 
         // Player-specific methods
         void handleInput();
-        void followMouse(const sf::Vector2f& mousePosition);
         sf::Vector2f getTargetPosition() const { return m_targetPosition; }
-        bool isUsingMouseControl() const { return m_useMouseControl; }
 
         // Sprite initialization
         void initializeSprite(SpriteManager& spriteManager);
@@ -48,9 +46,6 @@ namespace FishGame
         int getScore() const { return m_score; }
         float getGrowthProgress() const { return m_growthProgress; }
 
-        void enableMouseControl(bool enable);
-        void setMousePosition(const sf::Vector2f& screenPos);
-        bool isMouseControlActive() const { return m_mouseControlActive; }
         void setAutoOrient(bool enable) { m_autoOrient = enable; }
 
         // Points tracking
@@ -108,11 +103,6 @@ namespace FishGame
         int m_currentStage;
         float m_growthProgress;
 
-        // Mouse control enhancements
-        bool m_mouseControlActive;
-        static constexpr float m_mouseDeadzone = 2.0f;
-        static constexpr float m_mouseSmoothingFactor = 0.15f;
-
         // Auto-orientation
         bool m_autoOrient;
         static constexpr float m_orientationThreshold = 5.0f;
@@ -121,7 +111,6 @@ namespace FishGame
         int m_points;
 
         // Control state
-        bool m_useMouseControl;
         sf::Vector2f m_targetPosition;
         bool m_controlsReversed{ false };
         sf::Time m_poisonColorTimer{ sf::Time::Zero };

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -24,9 +24,7 @@ namespace FishGame
         , m_currentStage(1)
         , m_growthProgress(0.0f)
         , m_points(0)
-        , m_useMouseControl(false)
         , m_targetPosition(0.0f, 0.0f)
-        , m_mouseControlActive(true)
         , m_autoOrient(true)
         , m_growthMeter(nullptr)
         , m_frenzySystem(nullptr)
@@ -116,42 +114,6 @@ namespace FishGame
         // Handle input
         handleInput();
 
-        // Mouse control movement
-        if (m_mouseControlActive)
-        {
-            // Calculate direction to mouse
-            sf::Vector2f direction = m_targetPosition - m_position;
-            float distance = std::sqrt(direction.x * direction.x + direction.y * direction.y);
-
-            if (distance > m_mouseDeadzone)
-            {
-                // Normalize direction
-                direction /= distance;
-
-                // Calculate speed based on power-ups
-                float effectiveSpeed = m_baseSpeed;
-                if (m_speedBoostTimer > sf::Time::Zero)
-                    effectiveSpeed *= m_speedMultiplier;
-
-                // Target velocity
-                sf::Vector2f targetVelocity = direction * effectiveSpeed;
-
-                // Smooth velocity transition
-                m_velocity.x = m_velocity.x + (targetVelocity.x - m_velocity.x) * m_mouseSmoothingFactor;
-                m_velocity.y = m_velocity.y + (targetVelocity.y - m_velocity.y) * m_mouseSmoothingFactor;
-            }
-            else
-            {
-                // Close to target - decelerate smoothly
-                m_velocity *= (1.0f - m_deceleration * deltaTime.asSeconds());
-
-                // Stop completely when very slow
-                if (std::abs(m_velocity.x) < 1.0f && std::abs(m_velocity.y) < 1.0f)
-                {
-                    m_velocity = sf::Vector2f(0.0f, 0.0f);
-                }
-            }
-        }
 
         // Limit maximum speed
         float maxSpeed = m_maxSpeed * (m_speedBoostTimer > sf::Time::Zero ? m_speedMultiplier : 1.0f);
@@ -235,7 +197,7 @@ namespace FishGame
 
     void Player::handleInput()
     {
-        // Check for keyboard input - this will override mouse control
+        // Check for keyboard input
         sf::Vector2f inputDirection(0.0f, 0.0f);
         bool keyboardUsed = false;
 
@@ -265,11 +227,9 @@ namespace FishGame
             inputDirection = -inputDirection;
         }
 
-        // Switch to keyboard control if keys are pressed
+        // Apply movement if any keyboard input was detected
         if (keyboardUsed)
         {
-            m_mouseControlActive = false;
-
             // Normalize diagonal movement
             float length = std::sqrt(inputDirection.x * inputDirection.x + inputDirection.y * inputDirection.y);
             if (length > 0.0f)
@@ -279,16 +239,11 @@ namespace FishGame
                 m_velocity = inputDirection * speed;
             }
         }
-        else if (!m_mouseControlActive)
+        else
         {
             // Apply deceleration when no keyboard input
             m_velocity *= 0.9f;
         }
-    }
-
-    void Player::followMouse(const sf::Vector2f& mousePosition)
-    {
-        m_targetPosition = mousePosition;
     }
 
     sf::FloatRect Player::getBounds() const
@@ -371,18 +326,6 @@ namespace FishGame
         m_poisonColorTimer = sf::Time::Zero;
     }
 
-    void Player::enableMouseControl(bool enable)
-    {
-        m_mouseControlActive = enable;
-    }
-
-    void Player::setMousePosition(const sf::Vector2f& screenPos)
-    {
-        if (!m_mouseControlActive)
-            return;
-
-        m_targetPosition = screenPos;
-    }
 
     bool Player::canEat(const Entity& other) const
     {

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -108,12 +108,7 @@ namespace FishGame
                     });
             }
         }
-        else if (event.type == sf::Event::MouseMoved)
-        {
-            sf::Vector2f worldPos = getGame().getWindow().mapPixelToCoords(
-                sf::Vector2i(event.mouseMove.x, event.mouseMove.y));
-            m_player->followMouse(worldPos);
-        }
+
     }
 
     bool BonusStageState::update(sf::Time deltaTime)

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -256,7 +256,6 @@ namespace FishGame
             case sf::Keyboard::Down:
             case sf::Keyboard::Left:
             case sf::Keyboard::Right:
-                // Re-enable mouse control automatically happens in Player
                 break;
 
             default:
@@ -265,40 +264,10 @@ namespace FishGame
             break;
 
         case sf::Event::MouseMoved:
-        {
-            // Get mouse position relative to window
-            sf::Vector2f mousePos(static_cast<float>(event.mouseMove.x),
-                static_cast<float>(event.mouseMove.y));
-
-            // Apply control reversal if active
-            if (m_hasControlsReversed)
-            {
-                auto windowSize = getGame().getWindow().getSize();
-                mousePos.x = windowSize.x - mousePos.x;
-                mousePos.y = windowSize.y - mousePos.y;
-            }
-
-            // Convert window coordinates to world coordinates if using camera
-            sf::Vector2f worldPos = getGame().getWindow().mapPixelToCoords(
-                sf::Vector2i(static_cast<int>(mousePos.x), static_cast<int>(mousePos.y)),
-                m_view
-            );
-
-            // Update player target position
-            m_player->setMousePosition(worldPos);
-
-            // Re-enable mouse control when mouse moves
-            m_player->enableMouseControl(true);
-        }
-        break;
+            // Mouse input disabled
+            break;
 
         case sf::Event::MouseButtonPressed:
-            // Re-enable mouse control on click
-            if (processedEvent.mouseButton.button == sf::Mouse::Left ||
-                processedEvent.mouseButton.button == sf::Mouse::Right)
-            {
-                m_player->enableMouseControl(true);
-            }
             break;
 
         default:
@@ -1286,15 +1255,7 @@ namespace FishGame
         window.draw(*m_growthMeter);
         window.draw(*m_frenzySystem);
 
-        // If paused, temporarily show cursor
-        if (getGame().getCurrentState<PauseState>())
-        {
-            getGame().getWindow().setMouseCursorVisible(true);
-        }
-        else
-        {
-            getGame().getWindow().setMouseCursorVisible(false);
-        }
+
 
         // Render HUD texts
         window.draw(m_hud.scoreText);
@@ -1328,12 +1289,7 @@ namespace FishGame
             resetLevel();
             updateLevelDifficulty();
 
-            // Hide mouse cursor for Feeding Frenzy-style control
-            getGame().getWindow().setMouseCursorVisible(false);
-
-            // Enable mouse control on the player
-            m_player->enableMouseControl(true);
-            m_player->setAutoOrient(true);
+            // Mouse control disabled
 
             m_hud.messageText.setString("");
             m_initialized = true;


### PR DESCRIPTION
## Summary
- cut mouse control functions from `Player`
- drop mouse event handling from `PlayState` and `BonusStageState`
- stop hiding the cursor during play

## Testing
- `cmake -S . -B build` *(fails: SFML not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dc1f8ee08333970f70c1519f143d