### PR TITLE
Fix unused iterator warning in Game.cpp

### DIFF
--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -133,7 +133,7 @@ namespace FishGame
             };
 
         // Update states until one returns false (blocks updates below)
-        auto it = std::find_if(m_stateStack.rbegin(), m_stateStack.rend(),
+        [[maybe_unused]] auto it = std::find_if(m_stateStack.rbegin(), m_stateStack.rend(),
             [&updateState](const StatePtr& state)
             {
                 return !updateState(state);


### PR DESCRIPTION
## Summary
- silence warning about unused iterator in `src/Core/Game.cpp`

## Testing
- `cmake -S . -B build` *(fails: could not find SFMLConfig.cmake)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_6859e003136c8333979c1d0d7ed4f372