### PR TITLE
Remove old texture enum usage

### DIFF
--- a/include/Core/ResourceHolder.h
+++ b/include/Core/ResourceHolder.h
@@ -10,16 +10,6 @@
 
 namespace FishGame
 {
-    // Resource identifiers
-    enum class Textures
-    {
-        Player,
-        SmallFish,
-        MediumFish,
-        LargeFish,
-        Background
-    };
-
     enum class Fonts
     {
         Main,
@@ -122,6 +112,5 @@ namespace FishGame
     }
 
     // Type aliases for convenience
-    using TextureHolder = ResourceHolder<sf::Texture, Textures>;
     using FontHolder = ResourceHolder<sf::Font, Fonts>;
 }


### PR DESCRIPTION
## Summary
- drop obsolete `Textures` enum
- remove `TextureHolder` alias

## Testing
- `cmake --preset x64-Debug` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6859e2c33bf883338c7ee3cab7d4e526