### PR TITLE
Remove unused player statistics

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -42,11 +42,6 @@ namespace FishGame
         void addPoints(int points);
         void resetSize();
         void fullReset();
-        int getCurrentStage() const { return m_currentStage; }
-        int getScore() const { return m_score; }
-        float getGrowthProgress() const { return m_growthProgress; }
-
-        void setAutoOrient(bool enable) { m_autoOrient = enable; }
 
         // Points tracking
         int getPoints() const { return m_points; }
@@ -73,16 +68,12 @@ namespace FishGame
         // Poison effect
         void applyPoisonEffect(sf::Time duration);
         void setControlsReversed(bool reversed) { m_controlsReversed = reversed; }
-        bool areControlsReversed() const { return m_controlsReversed; }
 
         // Size information
         bool isAtMaxSize() const { return m_currentStage >= Constants::MAX_STAGES; }
         void setWindowBounds(const sf::Vector2u& windowSize);
 
         // Statistics tracking
-        int getTotalFishEaten() const { return m_totalFishEaten; }
-        int getDamageTaken() const { return m_damageTaken; }
-        bool hasTakenDamage() const { return m_damageTaken > 0; }
 
         // Visual effects
         void triggerEatEffect();
@@ -149,10 +140,6 @@ namespace FishGame
 
         // Window bounds
         sf::Vector2u m_windowBounds;
-
-        // Statistics
-        int m_totalFishEaten;
-        int m_damageTaken;
 
         // Visual effects
         struct VisualEffect

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -36,8 +36,6 @@ namespace FishGame
         , m_speedMultiplier(1.0f)
         , m_speedBoostTimer(sf::Time::Zero)
         , m_windowBounds(Constants::WINDOW_WIDTH, Constants::WINDOW_HEIGHT)
-        , m_totalFishEaten(0)
-        , m_damageTaken(0)
         , m_activeEffects()
         , m_eatAnimationScale(1.0f)
         , m_eatAnimationTimer(sf::Time::Zero)
@@ -320,8 +318,6 @@ namespace FishGame
     {
         resetSize();
         m_points = 0;
-        m_totalFishEaten = 0;
-        m_damageTaken = 0;
         m_controlsReversed = false;
         m_poisonColorTimer = sf::Time::Zero;
     }
@@ -399,7 +395,6 @@ namespace FishGame
 
             // Add points
             addPoints(pointsToAdd);
-            m_totalFishEaten++;
 
             // Visual growth
             grow(fish->getPointValue());
@@ -499,7 +494,6 @@ namespace FishGame
         if (m_invulnerabilityTimer > sf::Time::Zero)
             return;
 
-        m_damageTaken++;
         m_damageCooldown = m_damageCooldownDuration;
 
         if (m_scoreSystem)


### PR DESCRIPTION
## Summary
- remove unused player stats getters and mutator
- delete counters for total fish eaten and damage taken

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6859e2c6388883339f89033d003e308c