### PR TITLE
Remove unused score tracking

### DIFF
--- a/include/Systems/ScoreSystem.h
+++ b/include/Systems/ScoreSystem.h
@@ -71,9 +71,7 @@ namespace FishGame
 
         // Score tracking
         int getCurrentScore() const { return m_currentScore; }
-        int getTotalScore() const { return m_totalScore; }
         void setCurrentScore(int score) { m_currentScore = score; }
-        void addToTotalScore(int score) { m_totalScore += score; }
         void reset();
 
     private:
@@ -84,7 +82,6 @@ namespace FishGame
 
         // Score tracking
         int m_currentScore;
-        int m_totalScore;
 
         // Chain system
         int m_currentChain;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -959,7 +959,6 @@ namespace FishGame
     {
         m_gameState.currentLevel++;
         m_gameState.totalScore += m_scoreSystem->getCurrentScore();
-        m_scoreSystem->addToTotalScore(m_scoreSystem->getCurrentScore());
 
         if (m_gameState.currentLevel % 3 == 0)
         {

--- a/src/Systems/ScoreSystem.cpp
+++ b/src/Systems/ScoreSystem.cpp
@@ -89,7 +89,6 @@ namespace FishGame
     ScoreSystem::ScoreSystem(const sf::Font& font)
         : m_font(font)
         , m_currentScore(0)
-        , m_totalScore(0)
         , m_currentChain(0)
         , m_floatingScores()
     {


### PR DESCRIPTION
## Summary
- remove unused total score functions from `ScoreSystem`
- stop calling `addToTotalScore`

## Testing
- `cmake -S . -B build` *(fails: sfml-main target missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859e2d3085c8333a137db357b31653c