### PR TITLE
Introduce polymorphic fish scoring

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -3,6 +3,7 @@
 #include "Entity.h"
 #include "Animator.h"
 #include "Strategy.h"
+#include "GameConstants.h"
 #include <vector>
 #include <memory>
 #include <string>
@@ -64,6 +65,8 @@ namespace FishGame
 
         // Virtual methods for derived classes
         virtual int getPointValue() const { return m_pointValue; }
+        // Points awarded when this fish is eaten by the player
+        virtual int getScorePoints() const;
         virtual bool canEat(const Entity& other) const;
         virtual void updateAI(const std::vector<std::unique_ptr<Entity>>& entities,
             const Entity* player, sf::Time deltaTime);

--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -4,6 +4,7 @@
 #include "CollisionDetector.h"
 #include "GenericFish.h"
 #include "Animator.h"
+#include "GameConstants.h"
 #include <cmath>
 #include <algorithm>
 #include <vector>
@@ -53,6 +54,7 @@ namespace FishGame
         bool isSpecialFish() const override { return true; }
         bool isBarracuda() const override { return true; }
         TextureID getTextureID() const override { return TextureID::Barracuda; }
+        int getScorePoints() const override { return Constants::BARRACUDA_POINTS; }
 
         // Enhanced AI for aggressive hunting
         void updateAI(const std::vector<std::unique_ptr<Entity>>& entities,
@@ -99,6 +101,7 @@ namespace FishGame
         {
             return isInflated() ? TextureID::PufferfishInflated : TextureID::Pufferfish;
         }
+        int getScorePoints() const override { return Constants::PUFFERFISH_POINTS; }
 
         void update(sf::Time deltaTime) override;
         void initializeSprite(SpriteManager& spriteManager);
@@ -169,6 +172,7 @@ namespace FishGame
 
         EntityType getType() const override { return EntityType::SmallFish; }
         int getPointValue() const override { return m_poisonPoints; }
+        int getScorePoints() const override { return m_poisonPoints; }
 
         void update(sf::Time deltaTime) override;
 
@@ -204,6 +208,7 @@ namespace FishGame
         EntityType getType() const override { return EntityType::SmallFish; }
         int getPointValue() const { return m_bonusPoints; }
         TextureID getTextureID() const override { return TextureID::Angelfish; }
+        int getScorePoints() const override { return Constants::ANGELFISH_POINTS; }
 
         void update(sf::Time deltaTime) override;
 

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -548,17 +548,32 @@ namespace FishGame
         }
     }
 
-    void Fish::updateMovement(sf::Time deltaTime)
+void Fish::updateMovement(sf::Time deltaTime)
+{
+    if (m_movementStrategy)
     {
-        if (m_movementStrategy)
-        {
-            m_movementStrategy->update(*this, deltaTime);
-        }
-        else
-        {
-            m_position += m_velocity * deltaTime.asSeconds();
-        }
+        m_movementStrategy->update(*this, deltaTime);
     }
+    else
+    {
+        m_position += m_velocity * deltaTime.asSeconds();
+    }
+}
+
+int Fish::getScorePoints() const
+{
+    switch (m_size)
+    {
+    case FishSize::Small:
+        return Constants::SMALL_FISH_POINTS;
+    case FishSize::Medium:
+        return Constants::MEDIUM_FISH_POINTS;
+    case FishSize::Large:
+        return Constants::LARGE_FISH_POINTS;
+    default:
+        return 0;
+    }
+}
 
     int Fish::getPointValue(FishSize size, int level)
     {

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -365,36 +365,8 @@ namespace FishGame
         const Fish* fish = dynamic_cast<const Fish*>(&other);
         if (fish)
         {
-            int pointsToAdd = 0;
-
-            // Determine points based on fish type
-            if (dynamic_cast<const SmallFish*>(fish))
-            {
-                pointsToAdd = Constants::SMALL_FISH_POINTS;
-            }
-            else if (dynamic_cast<const MediumFish*>(fish))
-            {
-                pointsToAdd = Constants::MEDIUM_FISH_POINTS;
-            }
-            else if (dynamic_cast<const LargeFish*>(fish))
-            {
-                pointsToAdd = Constants::LARGE_FISH_POINTS;
-            }
-            else if (dynamic_cast<const Barracuda*>(fish))
-            {
-                pointsToAdd = Constants::BARRACUDA_POINTS;
-            }
-            else if (dynamic_cast<const Pufferfish*>(fish))
-            {
-                pointsToAdd = Constants::PUFFERFISH_POINTS;
-            }
-            else if (dynamic_cast<const Angelfish*>(fish))
-            {
-                pointsToAdd = Constants::ANGELFISH_POINTS;
-            }
-
-            // Add points
-            addPoints(pointsToAdd);
+            // Use polymorphic score value
+            addPoints(fish->getScorePoints());
 
             // Visual growth
             grow(fish->getPointValue());


### PR DESCRIPTION
## Summary
- generalize how fish award points by adding a virtual `getScorePoints()`
- implement default scoring for standard fish
- override scoring for special fish types
- simplify player eat logic to use the new method

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859e68824308333baaad9956b026020