### PR TITLE
Add custom exceptions

### DIFF
--- a/include/Core/GameExceptions.h
+++ b/include/Core/GameExceptions.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace FishGame
+{
+    class GameException : public std::runtime_error
+    {
+    public:
+        explicit GameException(const std::string& message)
+            : std::runtime_error(message) {}
+    };
+
+    class ResourceLoadException : public GameException
+    {
+    public:
+        explicit ResourceLoadException(const std::string& message)
+            : GameException(message) {}
+    };
+
+    class StateNotFoundException : public GameException
+    {
+    public:
+        explicit StateNotFoundException(const std::string& message)
+            : GameException(message) {}
+    };
+}

--- a/include/Core/ResourceHolder.h
+++ b/include/Core/ResourceHolder.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <stdexcept>
 #include <cassert>
+#include "GameExceptions.h"
 
 namespace FishGame
 {
@@ -32,10 +33,10 @@ namespace FishGame
         ResourceHolder(ResourceHolder&&) = default;
         ResourceHolder& operator=(ResourceHolder&&) = default;
 
-        [[nodiscard]] bool load(Identifier id, const std::string& filename);
+        void load(Identifier id, const std::string& filename);
 
         template<typename Parameter>
-        [[nodiscard]] bool load(Identifier id, const std::string& filename, const Parameter& secondParam);
+        void load(Identifier id, const std::string& filename, const Parameter& secondParam);
 
         Resource& get(Identifier id);
         const Resource& get(Identifier id) const;
@@ -49,30 +50,28 @@ namespace FishGame
 
     // Template implementations
 template<typename Resource, typename Identifier>
-[[nodiscard]] bool ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string& filename)
+void ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string& filename)
     {
         auto resource = std::make_unique<Resource>();
         if (!resource->loadFromFile(filename))
         {
-            return false;
+            throw ResourceLoadException("Failed to load resource: " + filename);
         }
 
         insertResource(id, std::move(resource));
-        return true;
     }
 
 template<typename Resource, typename Identifier>
 template<typename Parameter>
-[[nodiscard]] bool ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string& filename, const Parameter& secondParam)
+void ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string& filename, const Parameter& secondParam)
     {
         auto resource = std::make_unique<Resource>();
         if (!resource->loadFromFile(filename, secondParam))
         {
-            return false;
+            throw ResourceLoadException("Failed to load resource: " + filename);
         }
 
         insertResource(id, std::move(resource));
-        return true;
     }
 
     template<typename Resource, typename Identifier>

--- a/include/Managers/SpriteManager.h
+++ b/include/Managers/SpriteManager.h
@@ -84,7 +84,7 @@ namespace FishGame
         SpriteManager& operator=(const SpriteManager&) = delete;
 
         // Load all textures
-        bool loadTextures(const std::string& assetPath);
+        void loadTextures(const std::string& assetPath);
 
         // Get texture for entity
         const sf::Texture& getTexture(TextureID id) const;

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -7,7 +7,7 @@
 #include "PauseState.h"
 #include "GameOptionsState.h"
 #include <algorithm>
-#include <stdexcept>
+#include "GameExceptions.h"
 
 namespace FishGame
 {
@@ -32,10 +32,7 @@ namespace FishGame
         m_pendingList.reserve(10);
 
         // Load resources
-        if (!m_fonts.load(Fonts::Main, "Regular.ttf"))
-        {
-            throw std::runtime_error("Failed to load font: Regular.ttf");
-        }
+        m_fonts.load(Fonts::Main, "Regular.ttf");
 
         initializeGraphics();
 
@@ -91,10 +88,7 @@ namespace FishGame
         m_spriteManager = std::make_unique<SpriteManager>(*m_spriteTextures);
 
         // Load all sprite textures
-        if (!m_spriteManager->loadTextures(""))
-        {
-			//throw std::runtime_error("Failed to load sprite textures");
-        }
+        m_spriteManager->loadTextures("");
 
         // Configure sprite scales
         SpriteScaleConfig scaleConfig;
@@ -242,7 +236,8 @@ namespace FishGame
         auto found = m_stateFactories.find(id);
         if (found == m_stateFactories.end())
         {
-            throw std::runtime_error("State factory not found for StateID: " +
+            throw StateNotFoundException(
+                "State factory not found for StateID: " +
                 std::to_string(static_cast<int>(id)));
         }
 

--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -2,8 +2,8 @@
 #include "Entity.h"
 #include "Fish.h"
 #include "Player.h"
-#include <stdexcept>
 #include <algorithm>
+#include "GameExceptions.h"
 
 namespace FishGame
 {
@@ -63,24 +63,16 @@ namespace FishGame
     {
     }
 
-    bool SpriteManager::loadTextures(const std::string& assetPath)
+void SpriteManager::loadTextures(const std::string& assetPath)
     {
-        bool allLoaded = true;
-
         // Use STL algorithm to load all textures
         std::for_each(s_textureFiles.begin(), s_textureFiles.end(),
-            [this, &assetPath, &allLoaded](const auto& pair) {
+            [this, &assetPath](const auto& pair) {
                 const auto& [id, filename] = pair;
                 std::string fullPath = filename;
 
-                if (!m_textureHolder.load(id, fullPath))
-                {
-                    // Log error but continue loading other textures
-                    allLoaded = false;
-                }
+                m_textureHolder.load(id, fullPath);
             });
-
-        return allLoaded;
     }
 
     const sf::Texture& SpriteManager::getTexture(TextureID id) const


### PR DESCRIPTION
## Summary
- introduce `GameExceptions` hierarchy for error handling
- throw `ResourceLoadException` in `ResourceHolder` when assets fail to load
- update `Game` and `SpriteManager` to use the new exceptions
- throw `StateNotFoundException` if a state factory is missing

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6859e93b55508333ba9cc58930c45719