### PR TITLE
Fix some compiler warnings

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -33,7 +33,7 @@ namespace FishGame
         // New fleeing behavior methods
         void startFleeing();
         bool isFleeing() const { return m_isFleeing; }
-        void updateFleeingBehavior(sf::Time deltaTime);
+        void updateFleeingBehavior();
 
         void setFrozen(bool frozen);
         bool isFrozen() const { return m_isFrozen; }

--- a/include/Managers/BonusItemManager.h
+++ b/include/Managers/BonusItemManager.h
@@ -18,12 +18,13 @@ namespace FishGame
         EnhancedBonusSpawner(float spawnRate, const sf::Vector2u& windowSize, const sf::Font* font = nullptr)
             : m_spawnRate(spawnRate)
             , m_spawnTimer(sf::Time::Zero)
+            , m_shouldSpawn(false)
+            , m_enabled(true)
             , m_windowSize(windowSize)
             , m_font(font)
             , m_randomEngine(std::random_device{}())
             , m_xDistribution(0.0f, 1.0f)  // Initialize with valid range
             , m_yDistribution(0.0f, 1.0f)  // Initialize with valid range
-            , m_enabled(true)
         {
             // Set up distributions with validation
             float margin = 100.0f;

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -61,7 +61,7 @@ namespace FishGame
         m_isFleeing = true;
 
         // Determine flee direction based on position
-        float centerX = m_windowBounds.x / 2.0f;
+        float centerX = static_cast<float>(m_windowBounds.x) / 2.0f;
 
         // Flee to nearest edge
         if (m_position.x < centerX)
@@ -77,7 +77,7 @@ namespace FishGame
         m_velocity = m_fleeDirection * m_fleeSpeed;
     }
 
-    void Fish::updateFleeingBehavior(sf::Time deltaTime)
+    void Fish::updateFleeingBehavior()
     {
         if (!m_isFleeing)
             return;
@@ -292,14 +292,15 @@ namespace FishGame
         // Update fleeing behavior if active
         if (m_isFleeing)
         {
-            updateFleeingBehavior(deltaTime);
+            updateFleeingBehavior();
         }
 
         // Update position
         updateMovement(deltaTime);
 
         // Check if fish has moved off screen
-        if (m_velocity.x > 0 && m_position.x > m_windowBounds.x + m_radius)
+        if (m_velocity.x > 0 &&
+            m_position.x > static_cast<float>(m_windowBounds.x) + m_radius)
         {
             destroy();
         }

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -127,6 +127,7 @@ namespace FishGame
 
     void Bomb::onContact(Entity& entity)
     {
+        (void)entity;
         trigger();
     }
 

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -41,12 +41,12 @@ namespace FishGame
         , m_activeEffects()
         , m_eatAnimationScale(1.0f)
         , m_eatAnimationTimer(sf::Time::Zero)
+        , m_turnAnimationTimer(sf::Time::Zero)
         , m_damageFlashColor(sf::Color::White)
         , m_damageFlashIntensity(0.0f)
         , m_animator(nullptr)
         , m_currentAnimation()
         , m_facingRight(false)
-        , m_turnAnimationTimer(sf::Time::Zero)
     {
         m_radius = m_baseRadius;
 

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -43,7 +43,7 @@ namespace FishGame
         Fish::update(deltaTime);
     }
 
-    void AdvancedFish::updateMovementPattern(sf::Time deltaTime)
+    void AdvancedFish::updateMovementPattern(sf::Time /*deltaTime*/)
     {
         switch (m_movementPattern)
         {

--- a/src/Managers/EnhancedFishSpawner.cpp
+++ b/src/Managers/EnhancedFishSpawner.cpp
@@ -72,6 +72,7 @@ namespace FishGame
     template<typename SpecialFishType>
     void EnhancedFishSpawner::spawnSpecialFish(float spawnRate, sf::Time deltaTime)
     {
+        (void)deltaTime;
         std::string typeName;
 
         // Determine type name for timer lookup
@@ -134,7 +135,7 @@ namespace FishGame
             config.fishSize = FishSize::Medium;
         }
 
-        int schoolId = m_schoolingSystem->createSchool<FishType>(config);
+        m_schoolingSystem->createSchool<FishType>(config);
 
         // Spawn position for the school
         bool fromLeft = m_randomEngine() % 2 == 0;

--- a/src/States/GameOverState.cpp
+++ b/src/States/GameOverState.cpp
@@ -285,6 +285,7 @@ namespace FishGame
 
     void GameOverState::updateMenuSelection(sf::Time deltaTime)
     {
+        (void)deltaTime;
         if (m_isTransitioning) return;
 
         // Get mouse position for hover effects
@@ -349,6 +350,7 @@ namespace FishGame
 
     void GameOverState::handleMouseMove(const sf::Vector2f& mousePos)
     {
+        (void)mousePos;
         // Hover effect handled in updateMenuSelection
     }
 

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -723,7 +723,7 @@ namespace FishGame
                 state->handlePlayerDeath();
             }
         }
-        else if (auto* angel = dynamic_cast<Angelfish*>(&fish))
+        else if (dynamic_cast<Angelfish*>(&fish))
         {
             if (state->m_player->canEat(fish) && state->m_player->attemptEat(fish))
             {

--- a/src/Systems/FrenzySystem.cpp
+++ b/src/Systems/FrenzySystem.cpp
@@ -172,7 +172,6 @@ namespace FishGame
     {
         if (m_currentLevel != level)
         {
-            FrenzyLevel oldLevel = m_currentLevel;
             m_currentLevel = level;
 
             // Update visuals based on level


### PR DESCRIPTION
## Summary
- fix float conversion warnings in Fish
- mark unused parameters and variables
- reorder some constructor initializers
- tweak EnhancedFishSpawner to quiet unused parameter warning

## Testing
- `cmake ..`
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_6859ef86457883338c0a52ee25aadf91