### PR TITLE
Fix score rounding in calculation

### DIFF
--- a/include/Systems/ScoreSystem.h
+++ b/include/Systems/ScoreSystem.h
@@ -3,6 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <memory>
 #include <vector>
+#include <cmath>
 
 namespace FishGame
 {
@@ -98,6 +99,8 @@ namespace FishGame
     template<typename... Multipliers>
     int calculateTotalScore(int baseScore, Multipliers... multipliers)
     {
-        return baseScore * (... * multipliers);
+        float total = static_cast<float>(baseScore);
+        ((total *= multipliers), ...);
+        return static_cast<int>(std::round(total));
     }
 }


### PR DESCRIPTION
## Summary
- include `<cmath>` in ScoreSystem
- update `calculateTotalScore` to compute using floating point and round

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685a7e19044c8333a56fb9f2038c5517