### PR TITLE
Fix warnings by tweaking function parameters and initialization

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -69,7 +69,7 @@ namespace FishGame
         virtual int getScorePoints() const;
         virtual bool canEat(const Entity& other) const;
         virtual void updateAI(const std::vector<std::unique_ptr<Entity>>& entities,
-            const Entity* player, sf::Time deltaTime);
+            const Entity* player, sf::Time /*deltaTime*/);
 
         void setDirection(float dirX, float dirY);
         void setWindowBounds(const sf::Vector2u& windowSize);

--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -67,7 +67,7 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        void updateHuntingBehavior(const Entity* target, sf::Time deltaTime);
+        void updateHuntingBehavior(const Entity* target, sf::Time /*deltaTime*/);
 
     private:
         const Entity* m_currentTarget;
@@ -184,7 +184,7 @@ namespace FishGame
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     private:
-        void updatePoisonBubbles(sf::Time deltaTime);
+        void updatePoisonBubbles(sf::Time /*deltaTime*/);
 
     private:
         std::vector<sf::CircleShape> m_poisonBubbles;

--- a/include/Managers/EnhancedFishSpawner.h
+++ b/include/Managers/EnhancedFishSpawner.h
@@ -89,7 +89,7 @@ namespace FishGame
         float spacing = 50.0f;
         MovementPattern movementPattern = MovementPattern::Linear;
 
-        void applyToFish(FishType& fish, size_t index) const
+        void applyToFish(FishType& fish, [[maybe_unused]] size_t index) const
         {
             if constexpr (std::is_base_of_v<AdvancedFish, FishType>)
             {

--- a/include/Managers/GenericSpawner.h
+++ b/include/Managers/GenericSpawner.h
@@ -29,11 +29,13 @@ namespace FishGame
 
         explicit GenericSpawner(const ConfigType& config = {})
             : m_config(config)
+            , m_factory(nullptr)
             , m_spawnTimer(sf::Time::Zero)
+            , m_enabled(true)
+            , m_spawnBuffer()
             , m_randomEngine(std::random_device{}())
             , m_xDist(config.minBounds.x, config.maxBounds.x)
             , m_yDist(config.minBounds.y, config.maxBounds.y)
-            , m_enabled(true)
         {
         }
 

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -433,7 +433,7 @@ namespace FishGame
     }
 
     void Fish::updateAI(const std::vector<std::unique_ptr<Entity>>& entities,
-        const Entity* player, sf::Time deltaTime)
+        const Entity* player, sf::Time /*deltaTime*/)
     {
         // Skip AI if frozen, fleeing, or stunned
         if (m_isFrozen || m_isFleeing || m_isStunned)

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -51,7 +51,9 @@ namespace FishGame
         m_radius = m_baseRadius;
 
         // Start at center of screen
-        m_position = sf::Vector2f(m_windowBounds.x / 2.0f, m_windowBounds.y / 2.0f);
+        m_position = sf::Vector2f(
+            static_cast<float>(m_windowBounds.x) / 2.0f,
+            static_cast<float>(m_windowBounds.y) / 2.0f);
         m_targetPosition = m_position;
     }
 
@@ -425,8 +427,9 @@ namespace FishGame
                 tailOffset = (tailOffset / length) * other.getRadius() * 0.8f;
                 sf::Vector2f tailPos = fishPos + tailOffset;
 
-                float distance = std::sqrt(std::pow(m_position.x - tailPos.x, 2) +
-                    std::pow(m_position.y - tailPos.y, 2));
+                float dx = m_position.x - tailPos.x;
+                float dy = m_position.y - tailPos.y;
+                float distance = std::sqrt(dx * dx + dy * dy);
 
                 if (distance < m_radius + 10.0f)
                 {
@@ -478,7 +481,9 @@ namespace FishGame
 
     void Player::die()
     {
-        m_position = sf::Vector2f(m_windowBounds.x / 2.0f, m_windowBounds.y / 2.0f);
+        m_position = sf::Vector2f(
+            static_cast<float>(m_windowBounds.x) / 2.0f,
+            static_cast<float>(m_windowBounds.y) / 2.0f);
         m_velocity = sf::Vector2f(0.0f, 0.0f);
         m_targetPosition = m_position;
 
@@ -500,7 +505,9 @@ namespace FishGame
     void Player::respawn()
     {
         m_isAlive = true;
-        m_position = sf::Vector2f(m_windowBounds.x / 2.0f, m_windowBounds.y / 2.0f);
+        m_position = sf::Vector2f(
+            static_cast<float>(m_windowBounds.x) / 2.0f,
+            static_cast<float>(m_windowBounds.y) / 2.0f);
         m_velocity = sf::Vector2f(0.0f, 0.0f);
         m_targetPosition = m_position;
         m_invulnerabilityTimer = m_invulnerabilityDuration;
@@ -582,7 +589,8 @@ namespace FishGame
 
     void Player::updateStage()
     {
-        m_radius = m_baseRadius * std::pow(m_growthFactor, m_currentStage - 1);
+        m_radius = static_cast<float>(m_baseRadius *
+            std::pow(m_growthFactor, static_cast<float>(m_currentStage - 1)));
 
         if (m_growthMeter)
         {

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -228,7 +228,7 @@ namespace FishGame
         }
     }
 
-    void Barracuda::updateHuntingBehavior(const Entity* target, sf::Time deltaTime)
+    void Barracuda::updateHuntingBehavior(const Entity* target, sf::Time /*deltaTime*/)
     {
         sf::Vector2f direction = target->getPosition() - m_position;
         float distance = std::sqrt(direction.x * direction.x + direction.y * direction.y);
@@ -554,7 +554,7 @@ namespace FishGame
         updatePoisonBubbles(deltaTime);
     }
 
-    void PoisonFish::updatePoisonBubbles(sf::Time deltaTime)
+    void PoisonFish::updatePoisonBubbles(sf::Time /*deltaTime*/)
     {
         for (size_t i = 0; i < m_poisonBubbles.size(); ++i)
         {

--- a/src/Managers/EnhancedFishSpawner.cpp
+++ b/src/Managers/EnhancedFishSpawner.cpp
@@ -11,11 +11,11 @@ namespace FishGame
         , m_barracudaSpawner()
         , m_pufferfishSpawner()
         , m_angelfishSpawner()
+        , m_poisonFishSpawner()
         , m_specialConfig()
         , m_schoolingSystem(nullptr)
         , m_schoolChanceDist(0.0f, 1.0f)
         , m_schoolSizeDist(2, 3)  // Reduced from (2, 4) to (2, 3) - smaller schools
-        , m_poisonFishSpawner()
     {
         // Initialize special spawn timers
         m_specialSpawnTimers["barracuda"] = sf::Time::Zero;
@@ -103,7 +103,9 @@ namespace FishGame
 
             // Determine spawn position
             bool fromLeft = m_randomEngine() % 2 == 0;
-            float y = std::uniform_real_distribution<float>(100.0f, m_windowSize.y - 100.0f)(m_randomEngine);
+            float y = std::uniform_real_distribution<float>(
+                100.0f,
+                static_cast<float>(m_windowSize.y) - 100.0f)(m_randomEngine);
             float x = fromLeft ? -50.0f : m_windowSize.x + 50.0f;
 
             fish->setPosition(x, y);
@@ -139,7 +141,9 @@ namespace FishGame
 
         // Spawn position for the school
         bool fromLeft = m_randomEngine() % 2 == 0;
-        float baseY = std::uniform_real_distribution<float>(150.0f, m_windowSize.y - 150.0f)(m_randomEngine);
+        float baseY = std::uniform_real_distribution<float>(
+            150.0f,
+            static_cast<float>(m_windowSize.y) - 150.0f)(m_randomEngine);
         float baseX = fromLeft ? -50.0f : m_windowSize.x + 50.0f;
 
         // Create formation configuration

--- a/src/States/GameOverState.cpp
+++ b/src/States/GameOverState.cpp
@@ -69,8 +69,6 @@ namespace FishGame
 
     void GameOverState::render()
     {
-        auto& window = getGame().getWindow();
-
         renderBackground();
         renderParticles();
         renderStats();


### PR DESCRIPTION
## Summary
- silence unused parameter warnings in Fish and SpecialFish
- mark index parameter unused in EnhancedFishSpawner
- reorder constructor initialization in EnhancedFishSpawner and GenericSpawner
- convert window size to float in Player
- remove unused variable in GameOverState

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build` *(fails: warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_685a7dc0ddf48333945eee32cfac343b