### PR TITLE
Fix asset path usage in SpriteManager

### DIFF
--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -64,16 +64,20 @@ namespace FishGame
     }
 
 void SpriteManager::loadTextures(const std::string& assetPath)
-    {
+{
         // Use STL algorithm to load all textures
         std::for_each(s_textureFiles.begin(), s_textureFiles.end(),
-            [this, &assetPath](const auto& pair) {
+            [this, &assetPath](const auto& pair)
+            {
                 const auto& [id, filename] = pair;
-                std::string fullPath = filename;
+
+                // Prepend asset directory if provided
+                std::string fullPath = assetPath.empty() ? filename
+                    : assetPath + "/" + filename;
 
                 m_textureHolder.load(id, fullPath);
             });
-    }
+}
 
     const sf::Texture& SpriteManager::getTexture(TextureID id) const
     {


### PR DESCRIPTION
## Summary
- fix `SpriteManager::loadTextures` to use the provided asset path when constructing texture file paths

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*
- `make -C build` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685a808b817c8333ba4cfda6259f663e