### PR TITLE
Fix some warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+build/

--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -222,7 +222,7 @@ namespace FishGame
     private:
         void updateErraticMovement(sf::Time deltaTime);
         void updateEvasiveMovement(const std::vector<std::unique_ptr<Entity>>& entities,
-            const Entity* player, sf::Time deltaTime);
+            const Entity* player);
         sf::Vector2f calculateEscapeVector(const std::vector<const Entity*>& threats);
 
     private:

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -664,6 +664,7 @@ namespace FishGame
     void Angelfish::updateAI(const std::vector<std::unique_ptr<Entity>>& entities,
         const Entity* player, sf::Time deltaTime)
     {
+        (void)deltaTime;
         if (!m_isAlive || m_isFrozen || m_isStunned)
             return;
 
@@ -733,12 +734,12 @@ namespace FishGame
         // Calculate evasive movement
         if (!threats.empty())
         {
-            updateEvasiveMovement(entities, player, deltaTime);
+            updateEvasiveMovement(entities, player);
         }
     }
 
     void Angelfish::updateEvasiveMovement(const std::vector<std::unique_ptr<Entity>>& entities,
-        const Entity* player, sf::Time deltaTime)
+        const Entity* player)
     {
         std::vector<const Entity*> threats;
 

--- a/src/States/GameOptionsState.cpp
+++ b/src/States/GameOptionsState.cpp
@@ -25,7 +25,9 @@ namespace FishGame
         m_titleText.setFillColor(sf::Color::White);
         auto bounds = m_titleText.getLocalBounds();
         m_titleText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        m_titleText.setPosition(window.getSize().x / 2.f, window.getSize().y / 2.f - 40.f);
+        float winWidth = static_cast<float>(window.getSize().x);
+        float winHeight = static_cast<float>(window.getSize().y);
+        m_titleText.setPosition(winWidth / 2.f, winHeight / 2.f - 40.f);
 
         m_instructionText.setFont(font);
         m_instructionText.setString("Press Esc to return");
@@ -33,7 +35,7 @@ namespace FishGame
         m_instructionText.setFillColor(sf::Color::White);
         bounds = m_instructionText.getLocalBounds();
         m_instructionText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        m_instructionText.setPosition(window.getSize().x / 2.f, window.getSize().y / 2.f + 40.f);
+        m_instructionText.setPosition(winWidth / 2.f, winHeight / 2.f + 40.f);
     }
 
     void GameOptionsState::handleEvent(const sf::Event& event)

--- a/src/States/PauseState.cpp
+++ b/src/States/PauseState.cpp
@@ -25,7 +25,9 @@ namespace FishGame
         m_pauseText.setFillColor(sf::Color::White);
         sf::FloatRect bounds = m_pauseText.getLocalBounds();
         m_pauseText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        m_pauseText.setPosition(window.getSize().x / 2.f, window.getSize().y / 2.f - 40.f);
+        float winWidth = static_cast<float>(window.getSize().x);
+        float winHeight = static_cast<float>(window.getSize().y);
+        m_pauseText.setPosition(winWidth / 2.f, winHeight / 2.f - 40.f);
 
         m_instructionText.setFont(font);
         m_instructionText.setString("Press P or Esc to resume");
@@ -33,7 +35,7 @@ namespace FishGame
         m_instructionText.setFillColor(sf::Color::White);
         bounds = m_instructionText.getLocalBounds();
         m_instructionText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        m_instructionText.setPosition(window.getSize().x / 2.f, window.getSize().y / 2.f + 40.f);
+        m_instructionText.setPosition(winWidth / 2.f, winHeight / 2.f + 40.f);
     }
 
     void PauseState::handleEvent(const sf::Event& event)

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -844,6 +844,10 @@ namespace FishGame
             m_gameState.playerLives++;
             createParticleEffect(powerUp.getPosition(), sf::Color::Green, 15);
             break;
+
+        case PowerUpType::AddTime:
+            // Currently handled only in bonus stages
+            break;
         }
     }
 


### PR DESCRIPTION
## Summary
- fix unused deltaTime param in Angelfish AI
- remove deltaTime from updateEvasiveMovement
- silence warnings around window size conversions
- handle AddTime power up in PlayState
- ignore build directory

## Testing
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685a8082a7708333a56edc4a1ab92385