### PR TITLE
Fix rotation bug for special fish

### DIFF
--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -344,7 +344,7 @@ namespace FishGame
             );
 
             m_spikes[i].setPosition(spikePos);
-            m_spikes[i].setRotation(angle * Constants::DEG_TO_RAD);
+            m_spikes[i].setRotation(angle * Constants::RAD_TO_DEG);
         }
     }
 
@@ -650,7 +650,7 @@ namespace FishGame
             );
 
             m_fins[i].setPosition(finPos);
-            m_fins[i].setRotation(finAngle * Constants::DEG_TO_RAD);
+            m_fins[i].setRotation(finAngle * Constants::RAD_TO_DEG);
 
             // Pulse fins when evading (unless frozen)
             if (m_isEvading && !m_isFrozen)


### PR DESCRIPTION
## Summary
- correct angle conversion when rotating pufferfish spikes and fins

## Testing
- `cmake ..` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685a822c86e88333946e2609bafbc1e5