### PR TITLE
Fix rng seeding

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -32,7 +32,8 @@ namespace FishGame
         , m_scoreText()
         , m_timerBar()
         , m_timerBackground()
-        , m_randomEngine(std::chrono::steady_clock::now().time_since_epoch().count())
+        , m_randomEngine(static_cast<std::mt19937::result_type>(
+            std::chrono::steady_clock::now().time_since_epoch().count()))
         , m_xDist(100.0f, 1820.0f)
         , m_yDist(100.0f, 980.0f)
     {

--- a/src/States/GameOverState.cpp
+++ b/src/States/GameOverState.cpp
@@ -13,7 +13,8 @@ namespace FishGame
         , m_transitionAlpha(0.0f)
         , m_animationTime(0.0f)
         , m_fadeInTime(0.0f)
-        , m_randomEngine(std::chrono::steady_clock::now().time_since_epoch().count())
+        , m_randomEngine(static_cast<std::mt19937::result_type>(
+            std::chrono::steady_clock::now().time_since_epoch().count()))
     {
         m_particles.reserve(m_maxParticles);
     }

--- a/src/Systems/EnvironmentSystem.cpp
+++ b/src/Systems/EnvironmentSystem.cpp
@@ -62,7 +62,8 @@ namespace FishGame
     {
         m_elements.clear();
 
-        std::mt19937 rng(std::chrono::steady_clock::now().time_since_epoch().count());
+        std::mt19937 rng(static_cast<std::mt19937::result_type>(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
         std::uniform_real_distribution<float> xDist(0.0f, 2000.0f);
         std::uniform_real_distribution<float> yDist(100.0f, 900.0f);
         std::uniform_real_distribution<float> sizeDist(20.0f, 100.0f);
@@ -125,7 +126,8 @@ namespace FishGame
         m_particles.reserve(50);
 
         // Initialize current particles
-        std::mt19937 rng(std::chrono::steady_clock::now().time_since_epoch().count());
+        std::mt19937 rng(static_cast<std::mt19937::result_type>(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
         std::uniform_real_distribution<float> xDist(0.0f, static_cast<float>(Constants::WINDOW_WIDTH));
         std::uniform_real_distribution<float> yDist(0.0f, static_cast<float>(Constants::WINDOW_HEIGHT));
 
@@ -216,7 +218,8 @@ namespace FishGame
         , m_transitionTimer(sf::Time::Zero)
         , m_isTransitioning(false)
         , m_dayNightCyclePaused(true)  // Start paused by default
-        , m_randomEngine(std::chrono::steady_clock::now().time_since_epoch().count())
+        , m_randomEngine(static_cast<std::mt19937::result_type>(
+            std::chrono::steady_clock::now().time_since_epoch().count()))
         , m_timeDist(0, 3)
     {
         m_lightingOverlay.setFillColor(sf::Color(0, 0, 0, 0));


### PR DESCRIPTION
## Summary
- cast chrono epoch counts to `mt19937::result_type` when seeding

## Testing
- `cmake --preset x64-Debug` *(fails: Could not find package configuration file provided by "SFML")*
- `cmake --build --preset x64-Debug` *(fails: is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a83f9a4308333b83b406cd46bbed0