### PR TITLE
Switch to sprite-based collision

### DIFF
--- a/include/Animator.h
+++ b/include/Animator.h
@@ -24,6 +24,7 @@ public:
     void setScale(const sf::Vector2f& scale);
     sf::Vector2f getScale() const { return m_scale; }
     void setColor(const sf::Color& color) { m_sprite.setColor(color); }
+    sf::FloatRect getBounds() const { return m_sprite.getGlobalBounds(); }
 
 private:
     struct Clip

--- a/include/Core/StateUtils.h
+++ b/include/Core/StateUtils.h
@@ -82,7 +82,7 @@ namespace FishGame::StateUtils
                 if (!item2 || !item2->isAlive() || item1 == item2)
                     continue;
 
-                if (CollisionDetector::checkCircleCollision(*item1, *item2))
+                if (CollisionDetector::checkCollision(*item1, *item2))
                 {
                     onCollision(*item1, *item2);
                 }
@@ -100,7 +100,7 @@ namespace FishGame::StateUtils
         std::for_each(container.begin(), container.end(),
             [&entity, &onCollision](auto& item)
             {
-                if (item && item->isAlive() && CollisionDetector::checkCircleCollision(entity, *item))
+                if (item && item->isAlive() && CollisionDetector::checkCollision(entity, *item))
                 {
                     onCollision(*item);
                 }

--- a/include/Entities/Entity.h
+++ b/include/Entities/Entity.h
@@ -102,9 +102,9 @@ namespace FishGame
         };
 
         template<typename T>
-        concept CircularEntity = PositionProvider<T> && requires(const T& t)
+        concept BoundsProvider = requires(const T& t)
         {
-            { t.getRadius() } -> std::convertible_to<float>;
+            { t.getBounds() } -> std::convertible_to<sf::FloatRect>;
         };
 
         // Calculate distance squared between two entities (more efficient than distance)
@@ -122,12 +122,11 @@ namespace FishGame
             return std::sqrt(distanceSquared(a, b));
         }
 
-        // Check if two entities are colliding (circle collision)
-        template<CircularEntity A, CircularEntity B>
+        // Check if two entities are colliding using bounding boxes
+        template<BoundsProvider A, BoundsProvider B>
         inline bool areColliding(const A& a, const B& b) noexcept
         {
-            const float radiusSum = a.getRadius() + b.getRadius();
-            return distanceSquared(a, b) < (radiusSum * radiusSum);
+            return a.getBounds().intersects(b.getBounds());
         }
 
         // Apply a function to all alive entities in a container

--- a/include/Managers/OysterManager.h
+++ b/include/Managers/OysterManager.h
@@ -152,10 +152,7 @@ namespace FishGame
 
         static bool checkCollision(const Entity& a, const Entity& b)
         {
-            sf::Vector2f diff = a.getPosition() - b.getPosition();
-            float distSq = diff.x * diff.x + diff.y * diff.y;
-            float radiusSum = a.getRadius() + b.getRadius();
-            return distSq < radiusSum * radiusSum;
+            return a.getBounds().intersects(b.getBounds());
         }
 
     private:

--- a/include/Systems/CollisionDetector.h
+++ b/include/Systems/CollisionDetector.h
@@ -12,9 +12,9 @@ namespace FishGame
         // Delete constructor - this is a utility class with only static methods
         CollisionDetector() = delete;
 
-        // Check collision between two circular entities
-        template<EntityUtils::CircularEntity A, EntityUtils::CircularEntity B>
-        static bool checkCircleCollision(const A& entity1, const B& entity2)
+        // Check collision between two entities using bounding boxes
+        template<EntityUtils::BoundsProvider A, EntityUtils::BoundsProvider B>
+        static bool checkCollision(const A& entity1, const B& entity2)
         {
             return EntityUtils::areColliding(entity1, entity2);
         }

--- a/include/Systems/FishCollisionHandler.h
+++ b/include/Systems/FishCollisionHandler.h
@@ -33,7 +33,7 @@ namespace FishGame
                                 {
                                     if (!fish2->isAlive()) return;
 
-                                    if (CollisionDetector::checkCircleCollision(*fish1, *fish2))
+                                    if (CollisionDetector::checkCollision(*fish1, *fish2))
                                     {
                                         handleFishToFishCollision(*fish1, *fish2);
                                     }
@@ -59,7 +59,7 @@ namespace FishGame
                             {
                                 if (!hazard->isAlive()) return;
 
-                                if (CollisionDetector::checkCircleCollision(*fish, *hazard))
+                                if (CollisionDetector::checkCollision(*fish, *hazard))
                                 {
                                     handleFishToHazardCollision(*fish, *hazard);
                                 }

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -23,6 +23,8 @@ namespace FishGame
 
     sf::FloatRect BonusItem::getBounds() const
     {
+        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+            return getSpriteComponent()->getBounds();
         return sf::FloatRect(m_position.x - m_radius, m_position.y - m_radius,
             m_radius * 2.0f, m_radius * 2.0f);
     }

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -360,6 +360,13 @@ namespace FishGame
 
     sf::FloatRect Fish::getBounds() const
     {
+        if (m_renderMode == RenderMode::Sprite)
+        {
+            if (m_animator)
+                return m_animator->getBounds();
+            if (m_sprite)
+                return m_sprite->getBounds();
+        }
         return sf::FloatRect(m_position.x - m_radius, m_position.y - m_radius,
             m_radius * 2.0f, m_radius * 2.0f);
     }

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -120,6 +120,8 @@ namespace FishGame
 
     sf::FloatRect Bomb::getBounds() const
     {
+        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+            return getSpriteComponent()->getBounds();
         float effectiveRadius = m_isExploding ? m_explosionRadius : m_radius;
         return sf::FloatRect(m_position.x - effectiveRadius, m_position.y - effectiveRadius,
             effectiveRadius * 2.f, effectiveRadius * 2.f);
@@ -288,6 +290,8 @@ namespace FishGame
 
     sf::FloatRect Jellyfish::getBounds() const
     {
+        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+            return getSpriteComponent()->getBounds();
         // Include tentacle reach
         float effectiveRadius = m_radius + 15.0f;
         return sf::FloatRect(m_position.x - effectiveRadius, m_position.y - effectiveRadius,

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -248,6 +248,8 @@ namespace FishGame
 
     sf::FloatRect Player::getBounds() const
     {
+        if (m_renderMode == RenderMode::Sprite && m_animator)
+            return m_animator->getBounds();
         return sf::FloatRect(m_position.x - m_radius, m_position.y - m_radius,
             m_radius * 2.0f, m_radius * 2.0f);
     }
@@ -361,7 +363,8 @@ namespace FishGame
         float mouthRadius = m_radius * 0.5f;
 
         float distance = CollisionDetector::getDistance(mouthPos, other.getPosition());
-        if (distance > mouthRadius + other.getRadius())
+        float otherRadius = std::max(other.getBounds().width, other.getBounds().height) / 2.f;
+        if (distance > mouthRadius + otherRadius)
             return false;
 
         const Fish* fish = dynamic_cast<const Fish*>(&other);
@@ -424,7 +427,8 @@ namespace FishGame
             float length = std::sqrt(tailOffset.x * tailOffset.x + tailOffset.y * tailOffset.y);
             if (length > 0)
             {
-                tailOffset = (tailOffset / length) * other.getRadius() * 0.8f;
+                float otherRadius = std::max(other.getBounds().width, other.getBounds().height) / 2.f;
+                tailOffset = (tailOffset / length) * otherRadius * 0.8f;
                 sf::Vector2f tailPos = fishPos + tailOffset;
 
                 float dx = m_position.x - tailPos.x;

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -183,7 +183,7 @@ namespace FishGame
             [this](auto& item) {
                 if (auto* timePU = dynamic_cast<AddTimePowerUp*>(item.get()))
                 {
-                    if (CollisionDetector::checkCircleCollision(*m_player, *timePU))
+                    if (CollisionDetector::checkCollision(*m_player, *timePU))
                     {
                         timePU->onCollect();
                         m_timeLimit += sf::seconds(3.f);
@@ -319,7 +319,7 @@ namespace FishGame
             [this](auto& item) {
                 if (auto* perm = dynamic_cast<PermanentOyster*>(item.get()))
                 {
-                    if (perm->isOpen() && CollisionDetector::checkCircleCollision(*m_player, *perm))
+                    if (perm->isOpen() && CollisionDetector::checkCollision(*m_player, *perm))
                     {
                         perm->onCollect();
                         m_objective.currentCount++;
@@ -332,7 +332,7 @@ namespace FishGame
                         m_objectiveText.setString(objStream.str());
                     }
                     else if (m_oysterSafetyTimer <= sf::Time::Zero && perm->canDamagePlayer() &&
-                        CollisionDetector::checkCircleCollision(*m_player, *perm))
+                        CollisionDetector::checkCollision(*m_player, *perm))
                     {
                         m_objective.currentCount = 0;
                         completeStage();
@@ -358,7 +358,7 @@ namespace FishGame
             [this](auto& entity) {
                 if (SmallFish* fish = dynamic_cast<SmallFish*>(entity.get()))
                 {
-                    if (m_player->canEat(*fish) && CollisionDetector::checkCircleCollision(*m_player, *fish))
+                    if (m_player->canEat(*fish) && CollisionDetector::checkCollision(*m_player, *fish))
                     {
                         if (m_player->attemptEat(*fish))
                         {
@@ -394,7 +394,7 @@ namespace FishGame
             [this](auto& entity) {
                 if (Fish* fish = dynamic_cast<Fish*>(entity.get()))
                 {
-                    if (fish->canEat(*m_player) && CollisionDetector::checkCircleCollision(*m_player, *fish))
+                    if (fish->canEat(*m_player) && CollisionDetector::checkCollision(*m_player, *fish))
                     {
                         // Player dies - stage failed
                         m_objective.currentCount = 0;


### PR DESCRIPTION
## Summary
- use sprite bounds for collision detection
- route collision helpers and handlers to the new API
- expose bounds on Animator
- compute bounds from sprites when available

## Testing
- `cmake -S . -B build` *(fails: FindSFML.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9115b9508333a7a46be3028534a4