### PR TITLE
Fix pufferfish puff duration

### DIFF
--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -138,7 +138,7 @@ namespace FishGame
 
         // Timing constants
         static constexpr float m_normalStateDuration = 5.0f;  // 5 seconds normal
-        static constexpr float m_puffedStateDuration = 3.0f;  // 3 seconds puffed
+        static constexpr float m_puffedStateDuration = 5.0f;  // 5 seconds puffed
         static constexpr float m_inflationSpeed = 3.0f;
         static constexpr float m_deflationSpeed = 3.0f;
         static constexpr float m_inflatedRadiusMultiplier = 2.0f;

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -432,35 +432,38 @@ namespace FishGame
                 // Transition to puffed state
                 transitionToInflated();
             }
-            else
+            else if (m_inflationLevel > 0.0f)
             {
-                // Deflate if needed
-                if (m_inflationLevel > 0.0f)
-                {
-                    m_inflationLevel = std::max(0.0f, m_inflationLevel - m_deflationSpeed * deltaTime.asSeconds());
-
-                    // Update radius
-                    m_radius = m_normalRadius * (1.0f + m_inflationLevel * (m_inflatedRadiusMultiplier - 1.0f));
-                }
+                // Continue deflating back to normal size
+                m_inflationLevel = std::max(0.0f, m_inflationLevel - m_deflationSpeed * deltaTime.asSeconds());
+                m_radius = m_normalRadius * (1.0f + m_inflationLevel * (m_inflatedRadiusMultiplier - 1.0f));
             }
         }
         else
         {
             // Puffed state
-            if (m_stateTimer.asSeconds() >= m_puffedStateDuration)
+            if (m_stateTimer.asSeconds() < m_puffedStateDuration)
             {
-                // Transition to normal state
-                transitionToNormal();
-            }
-            else
-            {
-                // Inflate if needed
+                // Inflate until fully puffed
                 if (m_inflationLevel < 1.0f)
                 {
                     m_inflationLevel = std::min(1.0f, m_inflationLevel + m_inflationSpeed * deltaTime.asSeconds());
-
-                    // Update radius
                     m_radius = m_normalRadius * (1.0f + m_inflationLevel * (m_inflatedRadiusMultiplier - 1.0f));
+                }
+            }
+            else
+            {
+                // After puff duration elapsed, start deflating but remain puffed
+                if (m_inflationLevel > 0.0f)
+                {
+                    m_inflationLevel = std::max(0.0f, m_inflationLevel - m_deflationSpeed * deltaTime.asSeconds());
+                    m_radius = m_normalRadius * (1.0f + m_inflationLevel * (m_inflatedRadiusMultiplier - 1.0f));
+                }
+
+                // When back to normal size, switch to normal state
+                if (m_inflationLevel <= 0.0f)
+                {
+                    transitionToNormal();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- keep puff animation active while deflating
- increase puff duration to 5 seconds
- build with SFML to ensure compilation

## Testing
- `cmake -B build -S .`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685a9a0aea988333880224a1ecdd0d98