### PR TITLE
Fix Pufferfish puff duration

### DIFF
--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -335,12 +335,7 @@ namespace FishGame
             if (m_puffTimer.asSeconds() >= m_puffAnimDuration)
             {
                 m_isPuffing = false;
-                if (m_animator)
-                {
-                    std::string swim = m_facingRight ? "swimRight" : "swimLeft";
-                    m_animator->play(swim);
-                    m_currentAnimation = swim;
-                }
+                // Keep final puff frame until the puffed state ends
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure pufferfish keeps puff frame active until its puffed state ends

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685a9cf2f1b88333959e321ebb38afe3