### PR TITLE
Implement phased puff animation

### DIFF
--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -122,6 +122,8 @@ namespace FishGame
         void transitionToInflated();
         void transitionToNormal();
 
+        enum class PuffPhase { None, Inflating, Holding, Deflating };
+
     private:
         // State management
         bool m_isPuffed;
@@ -148,6 +150,7 @@ namespace FishGame
         bool m_isPuffing{ false };
         sf::Time m_puffTimer{ sf::Time::Zero };
         static constexpr float m_puffAnimDuration = 0.6f; // 6 frames * 0.1s
+        PuffPhase m_puffPhase{ PuffPhase::None };
     };
 
     // PoisonFish - Can be eaten but reverses controls when consumed

--- a/src/Animator.cpp
+++ b/src/Animator.cpp
@@ -261,7 +261,10 @@ Animator createPufferfishAnimator(const sf::Texture& tex)
     const int TURN_Y = 433;
 
     a.addClip("eatLeft", makeFrames(EAT_Y, 187, 7, 131), milliseconds(100), false);
-    a.addClip("puffLeft", makeFrames(PUFF_Y, 186, 6, 169), milliseconds(100), true, false, true);
+    a.addClip("puffInflateLeft", makeFrames(PUFF_Y, 186, 6, 169), milliseconds(100), false);
+    auto defFrames = makeFrames(PUFF_Y, 186, 6, 169);
+    std::reverse(defFrames.begin(), defFrames.end());
+    a.addClip("puffDeflateLeft", defFrames, milliseconds(100), false);
     a.addClip("swimLeft", makeFrames(SWIM_Y, 184, 15, 128), milliseconds(80));
 
     auto turnFrames = makeFrames(TURN_Y, 168, 5, 123);
@@ -270,7 +273,8 @@ Animator createPufferfishAnimator(const sf::Texture& tex)
     a.addClip("turnRightToLeft", turnFrames, milliseconds(90), false);
 
     a.copyFlip("eatLeft", "eatRight");
-    a.copyFlip("puffLeft", "puffRight");
+    a.copyFlip("puffInflateLeft", "puffInflateRight");
+    a.copyFlip("puffDeflateLeft", "puffDeflateRight");
     a.copyFlip("swimLeft", "swimRight");
 
     return a;


### PR DESCRIPTION
## Summary
- create enumerated puff phases and track state
- split puff animation into inflate/deflate clips
- update cycle logic to hold final frame for 5s before deflating
- transition correctly between phases

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685aa752c9848333b4920a9fe2bdfc82