### PR TITLE
Remove RenderMode enum and simplify sprite handling

### DIFF
--- a/include/Entities/Entity.h
+++ b/include/Entities/Entity.h
@@ -68,10 +68,7 @@ namespace FishGame
         SpriteComponent<Entity>* getSpriteComponent();
         const SpriteComponent<Entity>* getSpriteComponent() const;
 
-        // Visual mode
-        enum class RenderMode { Circle, Sprite };
-        void setRenderMode(RenderMode mode) { m_renderMode = mode; }
-        RenderMode getRenderMode() const { return m_renderMode; }
+
 
     protected:
         // Protected draw function for derived classes
@@ -88,7 +85,6 @@ namespace FishGame
 
         // Sprite component - using unique_ptr requires complete type in .cpp
         std::unique_ptr<SpriteComponent<Entity>> m_sprite;
-        RenderMode m_renderMode = RenderMode::Sprite;
     };
 
     // Utility functions for entity operations

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -97,7 +97,6 @@ namespace FishGame
             auto config = spriteManager.getSpriteConfig<Entity>(TextureID::Starfish);
             sprite->configure(config);
             setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
         }
     }
 
@@ -106,7 +105,7 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
         {
             getSpriteComponent()->update(deltaTime);
         }
@@ -137,7 +136,7 @@ namespace FishGame
 
     void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
         {
             target.draw(*getSpriteComponent(), states);
         }

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -108,7 +108,7 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
             getSpriteComponent()->update(deltaTime);
 
         // Update animations
@@ -138,7 +138,7 @@ namespace FishGame
 
     void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
         {
             target.draw(*getSpriteComponent(), states);
         }
@@ -159,7 +159,6 @@ namespace FishGame
             auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PowerUpExtraLife);
             sprite->configure(config);
             setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
         }
     }
 
@@ -191,7 +190,7 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
             getSpriteComponent()->update(deltaTime);
 
         // Update animations
@@ -235,7 +234,7 @@ namespace FishGame
 
     void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
         {
             target.draw(*getSpriteComponent(), states);
         }
@@ -257,7 +256,6 @@ namespace FishGame
             auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PowerUpSpeedBoost);
             sprite->configure(config);
             setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
         }
     }
 
@@ -272,11 +270,11 @@ namespace FishGame
         if (!updateLifetime(deltaTime))
             return;
 
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
             getSpriteComponent()->update(deltaTime);
 
         m_position.y = m_baseY + computeBobbingOffset();
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
             getSpriteComponent()->syncWithOwner();
     }
 
@@ -287,7 +285,7 @@ namespace FishGame
 
     void AddTimePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
         {
             target.draw(*getSpriteComponent(), states);
         }
@@ -302,7 +300,6 @@ namespace FishGame
             auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PowerUpAddTime);
             sprite->configure(config);
             setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
         }
     }
 }

--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -99,9 +99,6 @@ namespace FishGame
             sprite->configure(config);
             setSpriteComponent(std::move(sprite));
 
-            // Set render mode to sprite
-            setRenderMode(RenderMode::Sprite);
-
             // Apply initial visual state
             updateVisualState();
         }
@@ -313,7 +310,7 @@ namespace FishGame
         }
 
         // Update sprite or animator
-        if (m_animator && m_renderMode == RenderMode::Sprite)
+        if (m_animator)
         {
             bool newFacingRight = m_velocity.x > 0.f;
             if (!m_eating && std::abs(m_velocity.x) > 1.f && newFacingRight != m_facingRight)
@@ -354,7 +351,7 @@ namespace FishGame
 
             m_animator->setPosition(m_position);
         }
-        else if (m_sprite && m_renderMode == RenderMode::Sprite)
+        else if (m_sprite)
         {
             m_sprite->update(deltaTime);
             updateSpriteEffects(deltaTime);

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -217,7 +217,6 @@ namespace FishGame
             auto config = spriteManager.getSpriteConfig<Entity>(TextureID::Jellyfish);
             sprite->configure(config);
             setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
 
             // Set initial frame
             m_texture = &spriteManager.getTexture(TextureID::Jellyfish);
@@ -232,7 +231,7 @@ namespace FishGame
         if (!m_isAlive)
             return;
 
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
+        if (getSpriteComponent())
         {
             getSpriteComponent()->update(deltaTime);
 
@@ -303,8 +302,8 @@ namespace FishGame
 
     void Jellyfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getRenderMode() == RenderMode::Sprite && getSpriteComponent())
-    {
+        if (getSpriteComponent())
+        {
             target.draw(*getSpriteComponent(), states);
         }
         else

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -79,7 +79,6 @@ namespace FishGame
         const sf::Texture& tex = spriteManager.getTexture(getTextureID());
         m_animator = std::make_unique<Animator>(createFishAnimator(tex));
         m_animator->setPosition(m_position);
-        setRenderMode(RenderMode::Sprite);
         m_currentAnimation = "idleLeft";
         m_animator->play(m_currentAnimation);
     }
@@ -130,7 +129,7 @@ namespace FishGame
         constrainToWindow();
 
         // Auto-orient sprite based on velocity
-        if (m_autoOrient && m_animator && m_renderMode == RenderMode::Sprite && m_eatAnimationTimer <= sf::Time::Zero)
+        if (m_autoOrient && m_animator && m_eatAnimationTimer <= sf::Time::Zero)
         {
             if (std::abs(m_velocity.x) > m_orientationThreshold)
             {
@@ -150,7 +149,7 @@ namespace FishGame
         checkStageAdvancement();
         updateVisualEffects(deltaTime);
 
-        if (m_renderMode == RenderMode::Sprite && m_animator)
+        if (m_animator)
         {
             m_animator->update(deltaTime);
 
@@ -597,7 +596,7 @@ namespace FishGame
             m_growthMeter->setStage(m_currentStage);
         }
 
-        if (m_animator && m_renderMode == RenderMode::Sprite && m_spriteManager)
+        if (m_animator && m_spriteManager)
         {
             float stageScale = 1.0f;
             const auto& cfg = m_spriteManager->getScaleConfig();

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -109,7 +109,6 @@ namespace FishGame
         float scale = spriteManager.getScaleConfig().large * 1.5f;
         m_animator->setScale({ scale, scale });
         m_animator->setPosition(m_position);
-        setRenderMode(RenderMode::Sprite);
 
         m_facingRight = m_velocity.x > 0.f;
         m_currentAnimation = m_facingRight ? "swimRight" : "swimLeft";
@@ -130,7 +129,7 @@ namespace FishGame
     {
         AdvancedFish::update(deltaTime);
 
-        if (m_animator && getRenderMode() == RenderMode::Sprite)
+        if (m_animator)
         {
             bool newFacingRight = m_velocity.x > 0.f;
             if (newFacingRight != m_facingRight)
@@ -287,7 +286,6 @@ namespace FishGame
         float scale = spriteManager.getScaleConfig().medium;
         m_animator->setScale({ scale, scale });
         m_animator->setPosition(m_position);
-        setRenderMode(RenderMode::Sprite);
 
         m_facingRight = m_velocity.x > 0.f;
         m_currentAnimation = m_facingRight ? "swimRight" : "swimLeft";


### PR DESCRIPTION
## Summary
- remove `RenderMode` enum and related member from `Entity`
- rely on presence of sprite/animator components for drawing
- update all entity classes to drop render mode logic

## Testing
- `cmake -S . -B build` *(fails: could not find SFML package)*
- `cmake --build build` *(fails: no Makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_685aadf4452c833394babf7603084836