### PR TITLE
Check sprite texture before drawing

### DIFF
--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -136,10 +136,12 @@ namespace FishGame
 
     void Starfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
         {
-            target.draw(*getSpriteComponent(), states);
+            target.draw(*sprite, states);
         }
+        /*
         else
         {
             // Draw arms first
@@ -148,5 +150,6 @@ namespace FishGame
             // Draw center
             target.draw(m_shape, states);
         }
+        */
     }
 }

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -80,12 +80,22 @@ namespace FishGame
 
     void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
+        {
+            target.draw(*sprite, states);
+        }
+        /*
+        else
+        {
+            target.draw(m_aura, states);
+            target.draw(m_iconBackground, states);
 
-        DrawUtils::drawContainer(m_iceShards, target, states);
+            DrawUtils::drawContainer(m_iceShards, target, states);
 
-        target.draw(m_icon, states);
+            target.draw(m_icon, states);
+        }
+        */
     }
 
     // ExtraLifePowerUp implementation
@@ -138,16 +148,19 @@ namespace FishGame
 
     void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
         {
-            target.draw(*getSpriteComponent(), states);
+            target.draw(*sprite, states);
         }
+        /*
         else
         {
             target.draw(m_aura, states);
             target.draw(m_iconBackground, states);
             target.draw(m_heart, states);
         }
+        */
     }
 
     void ExtraLifePowerUp::initializeSprite(SpriteManager& spriteManager)
@@ -234,10 +247,12 @@ namespace FishGame
 
     void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
         {
-            target.draw(*getSpriteComponent(), states);
+            target.draw(*sprite, states);
         }
+        /*
         else
         {
             target.draw(m_aura, states);
@@ -245,6 +260,7 @@ namespace FishGame
 
             DrawUtils::drawContainer(m_speedLines, target, states);
         }
+        */
     }
 
     void SpeedBoostPowerUp::initializeSprite(SpriteManager& spriteManager)
@@ -285,9 +301,10 @@ namespace FishGame
 
     void AddTimePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
         {
-            target.draw(*getSpriteComponent(), states);
+            target.draw(*sprite, states);
         }
     }
 

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -133,8 +133,17 @@ namespace FishGame
 
     void Bomb::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (m_sprite)
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
+        {
+            target.draw(*sprite, states);
+        }
+        /*
+        else if (m_sprite)
+        {
             target.draw(*m_sprite, states);
+        }
+        */
     }
 
     void Bomb::advanceState()
@@ -302,10 +311,12 @@ namespace FishGame
 
     void Jellyfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        if (getSpriteComponent())
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
         {
-            target.draw(*getSpriteComponent(), states);
+            target.draw(*sprite, states);
         }
+        /*
         else
         {
             std::for_each(m_tentacles.begin(), m_tentacles.end(),
@@ -315,6 +326,7 @@ namespace FishGame
 
             target.draw(m_bell, states);
         }
+        */
     }
 
     void Jellyfish::pushEntity(Entity& entity) const

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -87,9 +87,19 @@ namespace FishGame
 
     void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
-        target.draw(m_icon, states);
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
+        {
+            target.draw(*sprite, states);
+        }
+        /*
+        else
+        {
+            target.draw(m_aura, states);
+            target.draw(m_iconBackground, states);
+            target.draw(m_icon, states);
+        }
+        */
     }
 
     // FrenzyStarterPowerUp implementation
@@ -159,11 +169,21 @@ namespace FishGame
 
     void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        target.draw(m_aura, states);
-        target.draw(m_iconBackground, states);
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
+        {
+            target.draw(*sprite, states);
+        }
+        /*
+        else
+        {
+            target.draw(m_aura, states);
+            target.draw(m_iconBackground, states);
 
-        // Draw lightning bolts
-        DrawUtils::drawContainer(m_lightningBolts, target, states);
+            // Draw lightning bolts
+            DrawUtils::drawContainer(m_lightningBolts, target, states);
+        }
+        */
     }
 
     // PowerUpManager implementation

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -409,17 +409,27 @@ namespace FishGame
 
     void Pufferfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        Fish::draw(target, states);
-
-        // Draw spikes when inflating
-        if (m_inflationLevel > 0.2f)
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
         {
-            std::for_each(m_spikes.begin(), m_spikes.end(),
-                [&target, &states](const sf::CircleShape& spike)
-                {
-                    target.draw(spike, states);
-                });
+            target.draw(*sprite, states);
         }
+        /*
+        else
+        {
+            Fish::draw(target, states);
+
+            // Draw spikes when inflating
+            if (m_inflationLevel > 0.2f)
+            {
+                std::for_each(m_spikes.begin(), m_spikes.end(),
+                    [&target, &states](const sf::CircleShape& spike)
+                    {
+                        target.draw(spike, states);
+                    });
+            }
+        }
+        */
     }
 
 
@@ -588,14 +598,24 @@ namespace FishGame
 
     void PoisonFish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        // Draw poison bubbles first
-        std::for_each(m_poisonBubbles.begin(), m_poisonBubbles.end(),
-            [&target, &states](const sf::CircleShape& bubble) {
-                target.draw(bubble, states);
-            });
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
+        {
+            target.draw(*sprite, states);
+        }
+        /*
+        else
+        {
+            // Draw poison bubbles first
+            std::for_each(m_poisonBubbles.begin(), m_poisonBubbles.end(),
+                [&target, &states](const sf::CircleShape& bubble) {
+                    target.draw(bubble, states);
+                });
 
-        // Draw the fish
-        Fish::draw(target, states);
+            // Draw the fish
+            Fish::draw(target, states);
+        }
+        */
     }
 
     // Angelfish implementation
@@ -854,14 +874,24 @@ namespace FishGame
 
     void Angelfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        // Draw fins first
-        std::for_each(m_fins.begin(), m_fins.end(),
-            [&target, &states](const sf::CircleShape& fin)
-            {
-                target.draw(fin, states);
-            });
+        const auto* sprite = getSpriteComponent();
+        if (sprite && sprite->getSprite().getTexture())
+        {
+            target.draw(*sprite, states);
+        }
+        /*
+        else
+        {
+            // Draw fins first
+            std::for_each(m_fins.begin(), m_fins.end(),
+                [&target, &states](const sf::CircleShape& fin)
+                {
+                    target.draw(fin, states);
+                });
 
-        Fish::draw(target, states);
+            Fish::draw(target, states);
+        }
+        */
     }
 
     void Angelfish::updateErraticMovement(sf::Time deltaTime)


### PR DESCRIPTION
## Summary
- guard draw calls with checks for a valid SpriteComponent and texture
- comment out fallback shape rendering
- updated BonusItem, PowerUp, Hazard, ExtendedPowerUps and SpecialFish draw methods

## Testing
- `cmake -S . -B build` *(fails: could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3aafbf883338a5025126e77256a