### PR TITLE
Fix compile error in PowerUp draw functions

### DIFF
--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -1,6 +1,7 @@
 #include "PowerUp.h"
 #include "GameConstants.h"
 #include "Utils/DrawHelpers.h"
+#include "SpriteManager.h"
 #include <cmath>
 #include <algorithm>
 #include <iterator>


### PR DESCRIPTION
## Summary
- include `SpriteManager.h` in PowerUp.cpp so SpriteComponent is fully defined

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j4`


------
https://chatgpt.com/codex/tasks/task_e_685ab71ea8a4833393b5349b52b91ebe