### PR TITLE
Update backgrounds per level

### DIFF
--- a/include/Managers/SpriteManager.h
+++ b/include/Managers/SpriteManager.h
@@ -51,7 +51,14 @@ namespace FishGame
         PowerUpExtraLife,
 
         // Environment
-        Background,
+        Background1,
+        Background2,
+        Background3,
+        Background4,
+        Background5,
+        Background6,
+        // legacy identifier kept for compatibility
+        Background = Background1,
         GameTitle
         , NewGame
         , NewGameHover

--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -4,6 +4,7 @@
 #include "BonusItem.h"
 #include "EnvironmentSystem.h"
 #include "Player.h"
+#include <SFML/Graphics.hpp>
 #include <memory>
 #include <vector>
 #include <random>
@@ -79,6 +80,7 @@ namespace FishGame
         std::vector<std::unique_ptr<Entity>> m_entities;
         std::vector<std::unique_ptr<BonusItem>> m_bonusItems;
         std::unique_ptr<EnvironmentSystem> m_environment;
+        sf::Sprite m_backgroundSprite;
 
         // Stage state
         sf::Time m_timeLimit = sf::Time::Zero;

--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -169,6 +169,7 @@ namespace FishGame
         void reverseControls();
         void showMessage(const std::string& message);
         void centerText(sf::Text& text);
+        void updateBackground(int level);
 
     private:
         // ==================== Core Game Objects ====================

--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -43,7 +43,12 @@ namespace FishGame
         {TextureID::PowerUpExtraLife, "PowerupLife.png"},
 
         // Environment
-        {TextureID::Background, "Background1.png"},
+        {TextureID::Background1, "Background1.png"},
+        {TextureID::Background2, "Background2.png"},
+        {TextureID::Background3, "Background3.png"},
+        {TextureID::Background4, "Background4.png"},
+        {TextureID::Background5, "Background5.png"},
+        {TextureID::Background6, "Background6.png"},
         {TextureID::GameTitle, "GameTitle.png"},
 
         // Menu sprites

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -22,6 +22,7 @@ namespace FishGame
         , m_entities()
         , m_bonusItems()
         , m_environment(std::make_unique<EnvironmentSystem>())
+        , m_backgroundSprite()
         , m_timeLimit(sf::Time::Zero)
         , m_timeElapsed(sf::Time::Zero)
         , m_objective()
@@ -54,6 +55,14 @@ namespace FishGame
         m_scoreText.setCharacterSize(28);
         m_scoreText.setFillColor(sf::Color::Green);
         m_scoreText.setPosition(50.0f, 150.0f);
+
+        // Background image for bonus stage
+        auto& window = getGame().getWindow();
+        m_backgroundSprite.setTexture(
+            getGame().getSpriteManager().getTexture(TextureID::Background6));
+        sf::Vector2f winSize(window.getSize());
+        sf::Vector2f texSize(m_backgroundSprite.getTexture()->getSize());
+        m_backgroundSprite.setScale(winSize.x / texSize.x, winSize.y / texSize.y);
 
         // Timer bar
         m_timerBackground.setSize(sf::Vector2f(400.0f, 20.0f));
@@ -236,6 +245,8 @@ namespace FishGame
     void BonusStageState::render()
     {
         auto& window = getGame().getWindow();
+
+        window.draw(m_backgroundSprite);
 
         // Draw environment
         window.draw(*m_environment);

--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -88,7 +88,7 @@ namespace FishGame
     {
         auto& window = getGame().getWindow();
         m_backgroundSprite.setTexture(
-            getGame().getSpriteManager().getTexture(TextureID::Background));
+            getGame().getSpriteManager().getTexture(TextureID::Background1));
 
         sf::Vector2f windowSize(window.getSize());
         sf::Vector2f texSize(m_backgroundSprite.getTexture()->getSize());

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -61,16 +61,9 @@ namespace FishGame
 
         // Setup background and camera
         auto& window = getGame().getWindow();
-        m_backgroundSprite.setTexture(
-            getGame().getSpriteManager().getTexture(TextureID::Background));
+        updateBackground(m_gameState.currentLevel);
 
         const sf::Vector2f windowSize(window.getSize());
-
-        // Scale background to always fill the window
-        const sf::Vector2f textureSize(m_backgroundSprite.getTexture()->getSize());
-        m_backgroundSprite.setScale(
-            windowSize.x / textureSize.x,
-            windowSize.y / textureSize.y);
 
         m_worldSize = windowSize;
 
@@ -964,6 +957,8 @@ namespace FishGame
         m_gameState.currentLevel++;
         m_gameState.totalScore += m_scoreSystem->getCurrentScore();
 
+        updateBackground(m_gameState.currentLevel);
+
         if (m_gameState.currentLevel % 3 == 0)
         {
             EnvironmentType newEnv = static_cast<EnvironmentType>(
@@ -1220,8 +1215,8 @@ namespace FishGame
         centerText(m_hud.messageText);
     }
 
-    void PlayState::centerText(sf::Text& text)
-    {
+void PlayState::centerText(sf::Text& text)
+{
         sf::FloatRect bounds = text.getLocalBounds();
         text.setOrigin(bounds.width / 2.0f, bounds.height / 2.0f);
         auto windowSize = getGame().getWindow().getSize();
@@ -1291,6 +1286,7 @@ namespace FishGame
 
             resetLevel();
             updateLevelDifficulty();
+            updateBackground(m_gameState.currentLevel);
 
             // Mouse control disabled
 
@@ -1307,6 +1303,7 @@ namespace FishGame
             m_returningFromBonusStage = false;
             m_savedLevel = 1;
             m_initialized = true;
+            updateBackground(m_gameState.currentLevel);
         }
 
         // Ensure camera starts centered on the player
@@ -1317,5 +1314,28 @@ namespace FishGame
     {
         // Show mouse cursor again when leaving play state
         getGame().getWindow().setMouseCursorVisible(true);
+    }
+
+    void PlayState::updateBackground(int level)
+    {
+        static const TextureID backgrounds[] = {
+            TextureID::Background1,
+            TextureID::Background2,
+            TextureID::Background3,
+            TextureID::Background4,
+            TextureID::Background5
+        };
+
+        int index = ((level - 1) / 2) % 5;
+        TextureID id = backgrounds[index];
+
+        auto& manager = getGame().getSpriteManager();
+        m_backgroundSprite.setTexture(manager.getTexture(id));
+
+        auto windowSize = getGame().getWindow().getSize();
+        auto texSize = m_backgroundSprite.getTexture()->getSize();
+        m_backgroundSprite.setScale(
+            static_cast<float>(windowSize.x) / texSize.x,
+            static_cast<float>(windowSize.y) / texSize.y);
     }
 }


### PR DESCRIPTION
## Summary
- expand `TextureID` enum to include six backgrounds
- load new background textures in `SpriteManager`
- adjust menu and play states to use level-based backgrounds
- draw special background in bonus stages

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_685ac24a2f208333a0f27e155317c820