### PR TITLE
Spawn fish from both sides

### DIFF
--- a/include/Managers/FishSpawner.h
+++ b/include/Managers/FishSpawner.h
@@ -14,7 +14,7 @@ namespace FishGame
         float spawnRate;     // Fish per second
         float minY;          // Minimum Y position
         float maxY;          // Maximum Y position
-        bool fromLeft;       // Spawn direction
+        bool fromLeft;       // Initial spawn side (unused)
     };
 
     class SpriteManager;

--- a/src/Managers/FishSpawner.cpp
+++ b/src/Managers/FishSpawner.cpp
@@ -82,10 +82,14 @@ namespace FishGame
         const auto& smallConfig = m_smallFishConfig[configLevel];
         SpawnerConfig<SmallFish> smallSpawnerConfig;
         smallSpawnerConfig.spawnRate = smallConfig.spawnRate;
-        smallSpawnerConfig.minBounds = sf::Vector2f(smallConfig.fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN, smallConfig.minY);
-        smallSpawnerConfig.maxBounds = sf::Vector2f(smallConfig.fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN, smallConfig.maxY);
-        smallSpawnerConfig.customizer = [this, &smallConfig](SmallFish& fish) {
-            fish.setDirection(smallConfig.fromLeft ? 1.0f : -1.0f, 0.0f);
+        // Allow spawning from either side by using the full horizontal range
+        smallSpawnerConfig.minBounds = sf::Vector2f(-SPAWN_MARGIN, smallConfig.minY);
+        smallSpawnerConfig.maxBounds = sf::Vector2f(m_windowSize.x + SPAWN_MARGIN, smallConfig.maxY);
+        smallSpawnerConfig.customizer = [this](SmallFish& fish) {
+            bool fromLeft = m_randomEngine() % 2 == 0;
+            float x = fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN;
+            fish.setPosition(x, fish.getPosition().y);
+            fish.setDirection(fromLeft ? 1.0f : -1.0f, 0.0f);
             fish.setWindowBounds(m_windowSize);
             fish.initializeSprite(*m_spriteManager);
             fish.setMovementStrategy(std::make_unique<RandomWanderStrategy>());
@@ -98,10 +102,13 @@ namespace FishGame
         const auto& mediumConfig = m_mediumFishConfig[configLevel];
         SpawnerConfig<MediumFish> mediumSpawnerConfig;
         mediumSpawnerConfig.spawnRate = mediumConfig.spawnRate;
-        mediumSpawnerConfig.minBounds = sf::Vector2f(mediumConfig.fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN, mediumConfig.minY);
-        mediumSpawnerConfig.maxBounds = sf::Vector2f(mediumConfig.fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN, mediumConfig.maxY);
-        mediumSpawnerConfig.customizer = [this, &mediumConfig](MediumFish& fish) {
-            fish.setDirection(mediumConfig.fromLeft ? 1.0f : -1.0f, 0.0f);
+        mediumSpawnerConfig.minBounds = sf::Vector2f(-SPAWN_MARGIN, mediumConfig.minY);
+        mediumSpawnerConfig.maxBounds = sf::Vector2f(m_windowSize.x + SPAWN_MARGIN, mediumConfig.maxY);
+        mediumSpawnerConfig.customizer = [this](MediumFish& fish) {
+            bool fromLeft = m_randomEngine() % 2 == 0;
+            float x = fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN;
+            fish.setPosition(x, fish.getPosition().y);
+            fish.setDirection(fromLeft ? 1.0f : -1.0f, 0.0f);
             fish.setWindowBounds(m_windowSize);
             fish.initializeSprite(*m_spriteManager);
 
@@ -121,10 +128,13 @@ namespace FishGame
         const auto& largeConfig = m_largeFishConfig[configLevel];
         SpawnerConfig<LargeFish> largeSpawnerConfig;
         largeSpawnerConfig.spawnRate = largeConfig.spawnRate;
-        largeSpawnerConfig.minBounds = sf::Vector2f(largeConfig.fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN, largeConfig.minY);
-        largeSpawnerConfig.maxBounds = sf::Vector2f(largeConfig.fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN, largeConfig.maxY);
-        largeSpawnerConfig.customizer = [this, &largeConfig](LargeFish& fish) {
-            fish.setDirection(largeConfig.fromLeft ? 1.0f : -1.0f, 0.0f);
+        largeSpawnerConfig.minBounds = sf::Vector2f(-SPAWN_MARGIN, largeConfig.minY);
+        largeSpawnerConfig.maxBounds = sf::Vector2f(m_windowSize.x + SPAWN_MARGIN, largeConfig.maxY);
+        largeSpawnerConfig.customizer = [this](LargeFish& fish) {
+            bool fromLeft = m_randomEngine() % 2 == 0;
+            float x = fromLeft ? -SPAWN_MARGIN : m_windowSize.x + SPAWN_MARGIN;
+            fish.setPosition(x, fish.getPosition().y);
+            fish.setDirection(fromLeft ? 1.0f : -1.0f, 0.0f);
             fish.setWindowBounds(m_windowSize);
             fish.initializeSprite(*m_spriteManager);
             fish.setMovementStrategy(std::make_unique<AggressiveChaseStrategy>(nullptr));


### PR DESCRIPTION
## Summary
- spawn small/medium/large fish randomly from either edge
- note in comments that spawn side field is now unused

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ada8bd828833386ce6f7c178ccbd6