### PR TITLE
Fix frenzy animation timing

### DIFF
--- a/include/Systems/FrenzySystem.h
+++ b/include/Systems/FrenzySystem.h
@@ -69,6 +69,7 @@ namespace FishGame
         float m_textScale;
         float m_textRotation;
         sf::Color m_currentColor;
+        sf::Time m_animationTimer;
 
         // Timing constants
         static constexpr float m_frenzyActivationTime = 2.0f;     // 4 fish in 2 seconds

--- a/src/Systems/FrenzySystem.cpp
+++ b/src/Systems/FrenzySystem.cpp
@@ -20,6 +20,7 @@ namespace FishGame
         , m_textScale(1.0f)
         , m_textRotation(0.0f)
         , m_currentColor(sf::Color::White)
+        , m_animationTimer(sf::Time::Zero)
     {
         // Setup frenzy text
         m_frenzyText.setFont(font);
@@ -173,6 +174,7 @@ namespace FishGame
         if (m_currentLevel != level)
         {
             m_currentLevel = level;
+            m_animationTimer = sf::Time::Zero;
 
             // Update visuals based on level
             switch (level)
@@ -208,9 +210,11 @@ namespace FishGame
     {
         if (m_currentLevel != FrenzyLevel::None)
         {
+            m_animationTimer += deltaTime;
+
             // Animate text
-            m_textScale = 1.0f + 0.1f * std::sin(deltaTime.asSeconds() * 5.0f);
-            m_textRotation = 5.0f * std::sin(deltaTime.asSeconds() * 3.0f);
+            m_textScale = 1.0f + 0.1f * std::sin(m_animationTimer.asSeconds() * 5.0f);
+            m_textRotation = 5.0f * std::sin(m_animationTimer.asSeconds() * 3.0f);
 
             // Update timer bar
             float timerPercentage = m_frenzyTimer.asSeconds() / m_frenzyMaintainTime;
@@ -223,7 +227,7 @@ namespace FishGame
             m_timerText.setString(timerStream.str());
 
             // Flash color
-            float flash = std::abs(std::sin(deltaTime.asSeconds() * 10.0f));
+            float flash = std::abs(std::sin(m_animationTimer.asSeconds() * 10.0f));
             sf::Color flashColor = m_currentColor;
             flashColor.r = static_cast<sf::Uint8>(flashColor.r + (255 - flashColor.r) * flash * 0.3f);
             flashColor.g = static_cast<sf::Uint8>(flashColor.g + (255 - flashColor.g) * flash * 0.3f);


### PR DESCRIPTION
## Summary
- fix visual animation by accumulating time in FrenzySystem

## Testing
- `cppcheck --error-exitcode=1 --enable=all -I include -I include/Core -I include/Entities -I include/Managers -I include/Systems --force --quiet src`
- `cmake ..` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_685ae01a2fbc83338718270e85b4ec91