### PR TITLE
Remove unused ScoreSystem enum values

### DIFF
--- a/include/Systems/ScoreSystem.h
+++ b/include/Systems/ScoreSystem.h
@@ -12,9 +12,7 @@ namespace FishGame
     {
         FishEaten,
         BonusCollected,
-        TailBite,
-        PowerUpCollected,
-        LevelComplete
+        TailBite
     };
 
     // Floating score text that appears when points are earned


### PR DESCRIPTION
## Summary
- prune unused enum values from `ScoreEventType`

## Testing
- `cmake -S . -B build` *(fails: could not find `SFML` package)*

------
https://chatgpt.com/codex/tasks/task_e_685afc999b90833389d03f8074c5ab1b