### PR TITLE
Remove unused Hazard::isFinished

### DIFF
--- a/include/Entities/Hazard.h
+++ b/include/Entities/Hazard.h
@@ -51,7 +51,6 @@ namespace FishGame
 
         // Control the explosion sequence
         void trigger();
-        bool isFinished() const;
 
         // Compatibility with old systems
         bool isExploding() const { return m_isExploding; }

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -173,10 +173,6 @@ namespace FishGame
             advanceState();
     }
 
-    bool Bomb::isFinished() const
-    {
-        return m_state == State::Done;
-    }
 
     // Jellyfish implementation
     Jellyfish::Jellyfish()


### PR DESCRIPTION
## Summary
- drop `isFinished` method from Bomb
- remove unused code in Hazard

## Testing
- `cmake -S . -B build` *(fails: could not find SFML package)*
- `cmake --build build` *(fails: no build files)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_685afc9b44748333a388109d06d0c748