### PR TITLE
Remove unused hazard activation members

### DIFF
--- a/include/Entities/Hazard.h
+++ b/include/Entities/Hazard.h
@@ -31,8 +31,6 @@ namespace FishGame
     protected:
         HazardType m_hazardType;
         float m_damageAmount;
-        sf::Time m_activationDelay;
-        bool m_isActivated;
     };
 
     // Bomb hazard - explodes on contact

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -15,8 +15,6 @@ namespace FishGame
         : Entity()
         , m_hazardType(type)
         , m_damageAmount(damageAmount)
-        , m_activationDelay(sf::Time::Zero)
-        , m_isActivated(true)
     {
     }
 


### PR DESCRIPTION
## Summary
- drop unused activation fields from `Hazard`
- update constructor accordingly

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685afc9ab3348333ab074d3abe5e55cb