### PR TITLE
Implement unordered_map reserve for resource holder

### DIFF
--- a/include/Core/ResourceHolder.h
+++ b/include/Core/ResourceHolder.h
@@ -3,7 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/Audio.hpp>
 #include <memory>
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <stdexcept>
 #include <cassert>
@@ -41,11 +41,13 @@ namespace FishGame
         Resource& get(Identifier id);
         const Resource& get(Identifier id) const;
 
+        void reserve(std::size_t count);
+
     private:
         void insertResource(Identifier id, std::unique_ptr<Resource> resource);
 
     private:
-        std::map<Identifier, std::unique_ptr<Resource>> m_resourceMap;
+        std::unordered_map<Identifier, std::unique_ptr<Resource>> m_resourceMap;
     };
 
     // Template implementations
@@ -108,6 +110,12 @@ void ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string
         {
             throw std::runtime_error("ResourceHolder::insertResource - Failed to insert resource");
         }
+    }
+
+    template<typename Resource, typename Identifier>
+    void ResourceHolder<Resource, Identifier>::reserve(std::size_t count)
+    {
+        m_resourceMap.reserve(count);
     }
 
     // Type aliases for convenience

--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -70,6 +70,7 @@ namespace FishGame
 
 void SpriteManager::loadTextures(const std::string& assetPath)
 {
+        m_textureHolder.reserve(s_textureFiles.size());
         // Use STL algorithm to load all textures
         std::for_each(s_textureFiles.begin(), s_textureFiles.end(),
             [this, &assetPath](const auto& pair)


### PR DESCRIPTION
## Summary
- use `std::unordered_map` inside `ResourceHolder`
- add `reserve()` API to reserve container capacity
- preallocate texture holder in `SpriteManager`

## Testing
- `cmake --preset x64-Debug`
- `cmake --build .` *(fails to run the executable due to missing display)*

------
https://chatgpt.com/codex/tasks/task_e_685b00973cf883339ee3052a2a0e5743