### PR TITLE
Remove unused font enumeration value

### DIFF
--- a/include/Core/ResourceHolder.h
+++ b/include/Core/ResourceHolder.h
@@ -13,8 +13,7 @@ namespace FishGame
 {
     enum class Fonts
     {
-        Main,
-        Score
+        Main
     };
 
     // Generic resource holder template


### PR DESCRIPTION
## Summary
- clean up `Fonts` enum by removing unused `Score` value

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685b044c1144833383653d7c4581b218