### PR TITLE
Remove unused special fish helpers

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -44,9 +44,6 @@ namespace FishGame
         bool isPoisoned() const { return m_isPoisoned; }
         bool isStunned() const { return m_isStunned; }
 
-        // Special fish type checking
-        virtual bool isSpecialFish() const { return false; }
-        virtual bool isBarracuda() const { return false; }
 
         // Entity interface implementation
         void update(sf::Time deltaTime) override;

--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -51,8 +51,6 @@ namespace FishGame
 
         EntityType getType() const override { return EntityType::LargeFish; }
 
-        bool isSpecialFish() const override { return true; }
-        bool isBarracuda() const override { return true; }
         TextureID getTextureID() const override { return TextureID::Barracuda; }
         int getScorePoints() const override { return Constants::BARRACUDA_POINTS; }
 
@@ -96,7 +94,6 @@ namespace FishGame
 
         EntityType getType() const override { return EntityType::MediumFish; }
 
-        bool isSpecialFish() const override { return true; }
         TextureID getTextureID() const override
         {
             return isInflated() ? TextureID::PufferfishInflated : TextureID::Pufferfish;
@@ -160,7 +157,6 @@ namespace FishGame
         explicit PoisonFish(int currentLevel = 1);
         ~PoisonFish() override = default;
 
-        bool isSpecialFish() const override { return true; }
         TextureID getTextureID() const override { return TextureID::PoisonFish; }
 
         EntityType getType() const override { return EntityType::SmallFish; }
@@ -171,7 +167,6 @@ namespace FishGame
 
         // Get poison effect duration when eaten
         sf::Time getPoisonDuration() const { return m_poisonDuration; }
-        bool isPoisonous() const { return true; }
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
@@ -197,7 +192,6 @@ namespace FishGame
         explicit Angelfish(int currentLevel = 1);
         ~Angelfish() override = default;
 
-        bool isSpecialFish() const override { return true; }
         EntityType getType() const override { return EntityType::SmallFish; }
         int getPointValue() const { return m_bonusPoints; }
         TextureID getTextureID() const override { return TextureID::Angelfish; }


### PR DESCRIPTION
## Summary
- drop unused helper methods from Fish
- remove isSpecialFish/isBarracuda overrides
- delete unused PoisonFish::isPoisonous

## Testing
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685b0468725c833392e13e472a7e2036