### PR TITLE
Add parallel update policy to BonusStageState

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -7,6 +7,7 @@
 #include "ExtendedPowerUps.h"
 #include "OysterManager.h"
 #include <algorithm>
+#include <execution>
 #include <sstream>
 #include <iomanip>
 #include <chrono>
@@ -169,7 +170,7 @@ namespace FishGame
         }
 
         // Update entities
-        std::for_each(m_entities.begin(), m_entities.end(),
+        std::for_each(std::execution::par_unseq, m_entities.begin(), m_entities.end(),
             [deltaTime, this](auto& entity) {
                 entity->update(deltaTime);
 
@@ -182,7 +183,7 @@ namespace FishGame
             });
 
         // Update bonus items
-        std::for_each(m_bonusItems.begin(), m_bonusItems.end(),
+        std::for_each(std::execution::par_unseq, m_bonusItems.begin(), m_bonusItems.end(),
             [deltaTime](auto& item) {
                 item->update(deltaTime);
             });


### PR DESCRIPTION
## Summary
- include `<execution>` for parallel algorithms
- update entity and bonus item loops to use `std::for_each` with `std::execution::par_unseq`

## Testing
- `cmake -B build -S .` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_685b069c193083339818ffc45de99a01