### PR TITLE
Fix various conversion warnings

### DIFF
--- a/include/Managers/OysterManager.h
+++ b/include/Managers/OysterManager.h
@@ -135,15 +135,15 @@ namespace FishGame
             // Generate positions using STL algorithm
             std::generate(xPositions.begin(), xPositions.end(),
                 [spacing, n = 1]() mutable {
-                    return spacing * n++;
+                    return spacing * static_cast<float>(n++);
                 });
 
             // Create oysters at fixed positions
             std::transform(xPositions.begin(), xPositions.end(), m_oysters.begin(),
                 [this](float x) {
                     auto oyster = std::make_unique<PermanentOyster>();
-                    oyster->setPosition(x, m_windowSize.y - 80.0f);
-                    oyster->m_baseY = m_windowSize.y - 80.0f;
+                    oyster->setPosition(x, static_cast<float>(m_windowSize.y) - 80.0f);
+                    oyster->m_baseY = static_cast<float>(m_windowSize.y) - 80.0f;
                     if (m_spriteManager)
                         oyster->initializeSprites(*m_spriteManager);
                     return oyster;

--- a/include/Systems/ScoreSystem.h
+++ b/include/Systems/ScoreSystem.h
@@ -98,7 +98,7 @@ namespace FishGame
     int calculateTotalScore(int baseScore, Multipliers... multipliers)
     {
         float total = static_cast<float>(baseScore);
-        ((total *= multipliers), ...);
+        ((total *= static_cast<float>(multipliers)), ...);
         return static_cast<int>(std::round(total));
     }
 }

--- a/src/Animator.cpp
+++ b/src/Animator.cpp
@@ -244,13 +244,13 @@ Animator createPufferfishAnimator(const sf::Texture& tex)
 {
     Animator a(tex, 187, 123, 5);
 
-    auto makeFrames = [](int rowY, int width, int count, int height)
+    auto makeFrames = [](int rowY, int width, std::size_t count, int height)
         {
             std::vector<sf::IntRect> frames;
             frames.reserve(count);
-            for (int i = 0; i < count; ++i)
+            for (std::size_t i = 0; i < count; ++i)
             {
-                frames.emplace_back(5 + i * width, rowY, width, height);
+                frames.emplace_back(5 + static_cast<int>(i) * width, rowY, width, height);
             }
             return frames;
         };

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -261,8 +261,9 @@ namespace FishGame
         // Update tentacles with wave motion
         for (size_t i = 0; i < m_tentacles.size(); ++i)
         {
-            float angle = (360.0f / m_tentacleCount) * i * Constants::DEG_TO_RAD;
-            float wave = std::sin(m_tentacleWave + i * 0.5f) * 10.0f;
+            float angle = (360.0f / static_cast<float>(m_tentacleCount)) *
+                static_cast<float>(i) * Constants::DEG_TO_RAD;
+            float wave = std::sin(m_tentacleWave + static_cast<float>(i) * 0.5f) * 10.0f;
 
             sf::Vector2f tentaclePos(
                 m_position.x + std::cos(angle) * 15.0f,

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -135,7 +135,7 @@ namespace FishGame
         // Update lightning bolts - rotate around center
         for (size_t i = 0; i < m_lightningBolts.size(); ++i)
         {
-            float angle = m_sparkAnimation + (i * 90.0f);
+            float angle = m_sparkAnimation + static_cast<float>(i) * 90.0f;
             float radius = 15.0f + 5.0f * std::sin(m_sparkAnimation * 2.0f);
 
             sf::Vector2f boltPos;

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -306,7 +306,8 @@ namespace FishGame
             // Still update visual elements but not state transitions
             for (size_t i = 0; i < m_spikes.size(); ++i)
             {
-                float angle = (360.0f / m_spikeCount) * i * Constants::DEG_TO_RAD;
+                float angle = (360.0f / static_cast<float>(m_spikeCount)) *
+                    static_cast<float>(i) * Constants::DEG_TO_RAD;
                 float spikeRadius = m_radius + (m_inflationLevel * 10.0f);
 
                 sf::Vector2f spikePos(
@@ -352,7 +353,8 @@ namespace FishGame
         // Update spike positions
         for (size_t i = 0; i < m_spikes.size(); ++i)
         {
-            float angle = (360.0f / m_spikeCount) * i * Constants::DEG_TO_RAD;
+            float angle = (360.0f / static_cast<float>(m_spikeCount)) *
+                static_cast<float>(i) * Constants::DEG_TO_RAD;
             float spikeRadius = m_radius + (m_inflationLevel * 10.0f);
 
             sf::Vector2f spikePos(
@@ -572,8 +574,8 @@ namespace FishGame
     {
         for (size_t i = 0; i < m_poisonBubbles.size(); ++i)
         {
-            float angle = (60.0f * i + m_wobbleAnimation * 30.0f) * Constants::DEG_TO_RAD;
-            float radius = 18.0f + 3.0f * std::sin(m_wobbleAnimation + i);
+            float angle = (60.0f * static_cast<float>(i) + m_wobbleAnimation * 30.0f) * Constants::DEG_TO_RAD;
+            float radius = 18.0f + 3.0f * std::sin(m_wobbleAnimation + static_cast<float>(i));
 
             sf::Vector2f bubblePos(
                 m_position.x + std::cos(angle) * radius,
@@ -583,7 +585,7 @@ namespace FishGame
             m_poisonBubbles[i].setPosition(bubblePos);
 
             // Pulsing effect for bubbles
-            float scale = 1.0f + 0.2f * std::sin(m_wobbleAnimation * 2.0f + i);
+            float scale = 1.0f + 0.2f * std::sin(m_wobbleAnimation * 2.0f + static_cast<float>(i));
             m_poisonBubbles[i].setScale(scale, scale);
         }
     }
@@ -655,7 +657,7 @@ namespace FishGame
         // Update fin positions with more dynamic movement
         for (size_t i = 0; i < m_fins.size(); ++i)
         {
-            float finAngle = (m_colorShift + i * 120.0f) * 3.14159f / 180.0f;
+            float finAngle = (m_colorShift + static_cast<float>(i) * 120.0f) * 3.14159f / 180.0f;
             float finRadius = 20.0f + (m_isEvading ? 10.0f * std::sin(m_colorShift * 5.0f) : 0.0f);
 
             sf::Vector2f finPos(

--- a/src/Managers/BonusItemManager.cpp
+++ b/src/Managers/BonusItemManager.cpp
@@ -82,12 +82,15 @@ namespace FishGame
         m_currentLevel = std::max(1, level);
 
         // Increase spawn rates based on level
-        float difficultyMultiplier = 1.0f + (m_currentLevel - 1) * 0.2f;
+        float difficultyMultiplier =
+            1.0f + static_cast<float>(m_currentLevel - 1) * 0.2f;
 
         m_starfishSpawner->setSpawnRate(m_baseStarfishRate * difficultyMultiplier);
 
         // Decrease power-up spawn interval for higher levels
-        m_powerUpSpawnInterval = m_basePowerUpInterval / (1.0f + (m_currentLevel - 1) * 0.1f);
+        m_powerUpSpawnInterval =
+            m_basePowerUpInterval /
+            (1.0f + static_cast<float>(m_currentLevel - 1) * 0.1f);
     }
 
     void BonusItemManager::setStarfishEnabled(bool enabled)
@@ -146,8 +149,9 @@ namespace FishGame
                 PowerUpType::ScoreDoubler, PowerUpType::FrenzyStarter,
                 PowerUpType::ScoreDoubler, PowerUpType::FrenzyStarter, PowerUpType::ExtraLife };
 
-        int index = std::uniform_int_distribution<int>(0, static_cast<int>(types.size()) - 1)(m_randomEngine);
-        PowerUpType type = types[index];
+        int index = std::uniform_int_distribution<int>(
+            0, static_cast<int>(types.size()) - 1)(m_randomEngine);
+        PowerUpType type = types[static_cast<std::size_t>(index)];
 
         using CreateFunc = std::unique_ptr<PowerUp>(*)(const sf::Font*);
         static constexpr std::array<CreateFunc, 6> creators = {

--- a/src/Managers/ConfiguredFishFactory.cpp
+++ b/src/Managers/ConfiguredFishFactory.cpp
@@ -24,7 +24,8 @@ namespace FishGame
 
                 // Calculate position based on pattern
                 sf::Vector2f position = calculatePosition(
-                    config.pattern, basePosition, index, config.spacing);
+                    config.pattern, basePosition, static_cast<std::size_t>(index),
+                    config.spacing);
 
                 fish->setPosition(position);
                 config.applyToFish(*fish, index);
@@ -47,13 +48,13 @@ namespace FishGame
         {
         case SpawnPattern::WaveFormation:
             return sf::Vector2f(
-                base.x + index * spacing,
-                base.y + std::sin(index * 0.5f) * 30.0f
+                base.x + static_cast<float>(index) * spacing,
+                base.y + std::sin(static_cast<float>(index) * 0.5f) * 30.0f
             );
 
         case SpawnPattern::CircleFormation:
         {
-            float angle = (360.0f / 8.0f) * index * Constants::DEG_TO_RAD;
+            float angle = (360.0f / 8.0f) * static_cast<float>(index) * Constants::DEG_TO_RAD;
             return sf::Vector2f(
                 base.x + std::cos(angle) * spacing,
                 base.y + std::sin(angle) * spacing
@@ -61,7 +62,7 @@ namespace FishGame
         }
 
         case SpawnPattern::LineFormation:
-            return sf::Vector2f(base.x, base.y + index * spacing);
+            return sf::Vector2f(base.x, base.y + static_cast<float>(index) * spacing);
 
         case SpawnPattern::EdgeRandom:
         default:

--- a/src/Managers/EnhancedFishSpawner.cpp
+++ b/src/Managers/EnhancedFishSpawner.cpp
@@ -61,7 +61,8 @@ namespace FishGame
         // Check for school spawning - ONLY FOR SMALL FISH
         if (m_schoolingSystem && m_schoolChanceDist(m_randomEngine) < m_specialConfig.schoolSpawnChance)
         {
-            size_t schoolSize = m_schoolSizeDist(m_randomEngine);
+            std::size_t schoolSize =
+                static_cast<std::size_t>(m_schoolSizeDist(m_randomEngine));
 
             // Only spawn schools of small fish
             spawnSchool<SmallFish>(schoolSize);
@@ -105,7 +106,7 @@ namespace FishGame
             float y = std::uniform_real_distribution<float>(
                 100.0f,
                 static_cast<float>(m_windowSize.y) - 100.0f)(m_randomEngine);
-            float x = fromLeft ? -50.0f : m_windowSize.x + 50.0f;
+            float x = fromLeft ? -50.0f : static_cast<float>(m_windowSize.x) + 50.0f;
 
             fish->setPosition(x, y);
             fish->setDirection(fromLeft ? 1.0f : -1.0f, 0.0f);
@@ -143,7 +144,7 @@ namespace FishGame
         float baseY = std::uniform_real_distribution<float>(
             150.0f,
             static_cast<float>(m_windowSize.y) - 150.0f)(m_randomEngine);
-        float baseX = fromLeft ? -50.0f : m_windowSize.x + 50.0f;
+        float baseX = fromLeft ? -50.0f : static_cast<float>(m_windowSize.x) + 50.0f;
 
         // Create formation configuration
         AdvancedSpawnConfig<FishType> spawnConfig;
@@ -187,7 +188,9 @@ namespace FishGame
         SpawnerConfig<Barracuda> barracudaConfig;
         barracudaConfig.spawnRate = m_specialConfig.barracudaSpawnRate * (1.0f + (level - 1) * 0.1f);
         barracudaConfig.minBounds = sf::Vector2f(-50.0f, 100.0f);
-        barracudaConfig.maxBounds = sf::Vector2f(m_windowSize.x + 50.0f, m_windowSize.y - 100.0f);
+        barracudaConfig.maxBounds =
+            sf::Vector2f(static_cast<float>(m_windowSize.x) + 50.0f,
+                        static_cast<float>(m_windowSize.y) - 100.0f);
 
         m_barracudaSpawner.setConfig(barracudaConfig);
         m_barracudaSpawner.setFactory([level]() { return FishFactory<Barracuda>::create(level); });
@@ -196,7 +199,9 @@ namespace FishGame
         SpawnerConfig<Pufferfish> pufferfishConfig;
         pufferfishConfig.spawnRate = m_specialConfig.pufferfishSpawnRate * (1.0f + (level - 1) * 0.15f);
         pufferfishConfig.minBounds = sf::Vector2f(-50.0f, 150.0f);
-        pufferfishConfig.maxBounds = sf::Vector2f(m_windowSize.x + 50.0f, m_windowSize.y - 150.0f);
+        pufferfishConfig.maxBounds =
+            sf::Vector2f(static_cast<float>(m_windowSize.x) + 50.0f,
+                        static_cast<float>(m_windowSize.y) - 150.0f);
 
         m_pufferfishSpawner.setConfig(pufferfishConfig);
         m_pufferfishSpawner.setFactory([level]() { return FishFactory<Pufferfish>::create(level); });
@@ -205,7 +210,9 @@ namespace FishGame
         SpawnerConfig<Angelfish> angelfishConfig;
         angelfishConfig.spawnRate = m_specialConfig.angelfishSpawnRate * (1.0f + (level - 1) * 0.2f);
         angelfishConfig.minBounds = sf::Vector2f(-50.0f, 50.0f);
-        angelfishConfig.maxBounds = sf::Vector2f(m_windowSize.x + 50.0f, m_windowSize.y - 50.0f);
+        angelfishConfig.maxBounds =
+            sf::Vector2f(static_cast<float>(m_windowSize.x) + 50.0f,
+                        static_cast<float>(m_windowSize.y) - 50.0f);
 
         m_angelfishSpawner.setConfig(angelfishConfig);
         m_angelfishSpawner.setFactory([level]() { return FishFactory<Angelfish>::create(level); });
@@ -214,7 +221,9 @@ namespace FishGame
         SpawnerConfig<PoisonFish> poisonFishConfig;
         poisonFishConfig.spawnRate = m_specialConfig.poisonFishSpawnRate * (1.0f + (level - 1) * 0.15f);
         poisonFishConfig.minBounds = sf::Vector2f(-50.0f, 50.0f);
-        poisonFishConfig.maxBounds = sf::Vector2f(m_windowSize.x + 50.0f, m_windowSize.y - 50.0f);
+        poisonFishConfig.maxBounds =
+            sf::Vector2f(static_cast<float>(m_windowSize.x) + 50.0f,
+                        static_cast<float>(m_windowSize.y) - 50.0f);
 
         m_poisonFishSpawner.setConfig(poisonFishConfig);
         m_poisonFishSpawner.setFactory([level]() { return FishFactory<PoisonFish>::create(level); });

--- a/src/Systems/EnvironmentSystem.cpp
+++ b/src/Systems/EnvironmentSystem.cpp
@@ -77,9 +77,9 @@ namespace FishGame
                 sf::RectangleShape coral(sf::Vector2f(sizeDist(rng), sizeDist(rng) * 1.5f));
                 coral.setPosition(xDist(rng), yDist(rng));
                 coral.setFillColor(sf::Color(
-                    m_baseColor.r + (rng() % 50),
-                    m_baseColor.g - (rng() % 30),
-                    m_baseColor.b + (rng() % 40),
+                    static_cast<sf::Uint8>(m_baseColor.r + (rng() % 50)),
+                    static_cast<sf::Uint8>(m_baseColor.g - (rng() % 30)),
+                    static_cast<sf::Uint8>(m_baseColor.b + (rng() % 40)),
                     m_baseColor.a));
                 return coral;
                 });
@@ -93,7 +93,7 @@ namespace FishGame
                 kelp.setOrigin(5.0f, sizeDist(rng) * 3.0f);
                 kelp.setFillColor(sf::Color(
                     0,
-                    m_baseColor.g + (rng() % 50),
+                    static_cast<sf::Uint8>(m_baseColor.g + (rng() % 50)),
                     0,
                     m_baseColor.a));
                 return kelp;
@@ -109,7 +109,7 @@ namespace FishGame
                 wave.setFillColor(sf::Color(
                     m_baseColor.r,
                     m_baseColor.g,
-                    m_baseColor.b + (rng() % 30),
+                    static_cast<sf::Uint8>(m_baseColor.b + (rng() % 30)),
                     m_baseColor.a / 2));
                 return wave;
                 });

--- a/src/Systems/FrenzySystem.cpp
+++ b/src/Systems/FrenzySystem.cpp
@@ -160,7 +160,8 @@ namespace FishGame
             auto recentStart = std::find_if(m_eatHistory.begin(), m_eatHistory.end(),
                 [](const EatEvent& event) { return event.timestamp.asSeconds() <= 2.5f; });
 
-            size_t recentCount = std::distance(recentStart, m_eatHistory.end());
+            std::size_t recentCount =
+                static_cast<std::size_t>(std::distance(recentStart, m_eatHistory.end()));
             if (recentCount >= m_requiredFishCount)
             {
                 setFrenzyLevel(FrenzyLevel::SuperFrenzy);

--- a/src/Systems/ScoreSystem.cpp
+++ b/src/Systems/ScoreSystem.cpp
@@ -118,7 +118,8 @@ namespace FishGame
         m_currentScore += totalPoints;
 
         // Create floating score
-        int displayMultiplier = static_cast<int>(std::round(frenzyMultiplier * powerUpMultiplier));
+        int displayMultiplier = static_cast<int>(std::round(
+            static_cast<float>(frenzyMultiplier) * powerUpMultiplier));
         createFloatingScore(totalPoints, displayMultiplier, position);
     }
 

--- a/src/UI/GrowthMeter.cpp
+++ b/src/UI/GrowthMeter.cpp
@@ -134,7 +134,8 @@ namespace FishGame
             sf::Color(0, 150, 255),
             sf::Color(255, 100, 0)
         };
-        m_fillBar.setFillColor(stageColors[m_currentStage - 1]);
+        m_fillBar.setFillColor(
+            stageColors[static_cast<std::size_t>(m_currentStage - 1)]);
 
         setPoints(m_points);
     }


### PR DESCRIPTION
## Summary
- adjust Animator frame lambda to use size_t
- fix size conversions in hazard, power-up, enhanced fish spawner and others
- clamp color conversions in environment system
- cast multipliers in score calculations
- correct index conversions in multiple managers and systems

## Testing
- `cmake --build build -j 4`

------
https://chatgpt.com/codex/tasks/task_e_685b08bcf69483339e56d8c8be7901c2