### PR TITLE
Modify bonus stage to starfish and bomb feeding frenzy

### DIFF
--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -4,6 +4,7 @@
 #include "BonusItem.h"
 #include "EnvironmentSystem.h"
 #include "Player.h"
+#include "Hazard.h"
 #include <SFML/Graphics.hpp>
 #include <memory>
 #include <vector>
@@ -55,6 +56,8 @@ namespace FishGame
         void spawnBonusFish();
         void spawnPredatorWave();
         void spawnTimePowerUp();
+        void spawnStarfish();
+        void spawnBomb();
 
         // Completion handling
         void checkCompletion();
@@ -79,6 +82,7 @@ namespace FishGame
         std::unique_ptr<Player> m_player;
         std::vector<std::unique_ptr<Entity>> m_entities;
         std::vector<std::unique_ptr<BonusItem>> m_bonusItems;
+        std::vector<std::unique_ptr<Hazard>> m_hazards;
         std::unique_ptr<EnvironmentSystem> m_environment;
         sf::Sprite m_backgroundSprite;
 

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -220,8 +220,8 @@ namespace FishGame
         // Register bonus stage
         m_stateFactories[StateID::BonusStage] = [this]() -> std::unique_ptr<State>
             {
-                // Default to treasure hunt, level 1
-                return std::make_unique<BonusStageState>(*this, BonusStageType::TreasureHunt, 1);
+                // Default to feeding frenzy, level 1
+                return std::make_unique<BonusStageState>(*this, BonusStageType::FeedingFrenzy, 1);
             };
 
         // TODO: Register additional states as they are implemented


### PR DESCRIPTION
## Summary
- switch bonus stage registration to feeding frenzy
- expand `BonusStageState` with hazard handling and new spawn helpers
- spawn bombs and starfish during feeding frenzy and draw/update them
- ignore objective count when timing the feeding frenzy stage

## Testing
- `cmake -S . -B build` *(fails: SFML not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b13c3d0388333bf0f4e17e68a54b1