### PR TITLE
Implement fish schools and adjust bonus stage timer

### DIFF
--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -5,6 +5,7 @@
 #include "EnvironmentSystem.h"
 #include "Player.h"
 #include "Hazard.h"
+#include "SpecialFish.h"
 #include <SFML/Graphics.hpp>
 #include <memory>
 #include <vector>
@@ -110,10 +111,13 @@ namespace FishGame
         // Short grace period after collecting a pearl to avoid instant failure
         sf::Time m_oysterSafetyTimer{ sf::Time::Zero };
 
+        // Tracking schools of bonus fish
+        std::vector<std::vector<SchoolMember<SmallFish>*>> m_fishSchools;
+
         // Stage configuration
         static constexpr int m_requiredPearlCount = 10;
         static constexpr float m_treasureHuntDuration = 30.0f;
-        static constexpr float m_feedingFrenzyDuration = 45.0f;
+        static constexpr float m_feedingFrenzyDuration = 15.0f;
         static constexpr float m_survivalDuration = 60.0f;
     };
 }

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -9,6 +9,7 @@
 #include "Hazard.h"
 #include "Systems/FishCollisionHandler.h"
 #include "OysterManager.h"
+#include <cmath>
 #include <algorithm>
 #include <execution>
 #include <sstream>
@@ -428,6 +429,37 @@ namespace FishGame
             spawnBomb();
         }
 
+        // Update schooling behavior for spawned fish
+        for (auto& group : m_fishSchools)
+        {
+            std::vector<SchoolMember<SmallFish>*> aliveMembers;
+            aliveMembers.reserve(group.size());
+
+            for (auto* member : group)
+            {
+                if (member && member->isAlive())
+                    aliveMembers.push_back(member);
+            }
+
+            for (auto* member : aliveMembers)
+            {
+                member->updateSchooling(aliveMembers, deltaTime);
+            }
+        }
+
+        m_fishSchools.erase(
+            std::remove_if(
+                m_fishSchools.begin(),
+                m_fishSchools.end(),
+                [](const auto& g)
+                {
+                    return std::none_of(g.begin(), g.end(), [](auto* m)
+                    {
+                        return m && m->isAlive();
+                    });
+                }),
+            m_fishSchools.end());
+
         // Check collisions with fish
         std::for_each(m_entities.begin(), m_entities.end(),
             [this](auto& entity) {
@@ -504,17 +536,32 @@ namespace FishGame
 
     void BonusStageState::spawnBonusFish()
     {
-        std::generate_n(std::back_inserter(m_entities), 5, [this] {
-            auto fish = std::make_unique<SmallFish>(m_playerLevel);
-            bool fromLeft = m_randomEngine() % 2 == 0;
-            float x = fromLeft ? -50.0f : 1970.0f;
-            float y = m_yDist(m_randomEngine);
+        const std::size_t count = 5;
+
+        bool fromLeft = m_randomEngine() % 2 == 0;
+        float baseX = fromLeft ? -50.0f : 1970.0f;
+        float baseY = m_yDist(m_randomEngine);
+
+        std::vector<SchoolMember<SmallFish>*> school;
+        school.reserve(count);
+
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            auto fish = std::make_unique<SchoolMember<SmallFish>>(m_playerLevel);
+            float xOffset = static_cast<float>(i) * 40.0f;
+            float yOffset = std::sin(static_cast<float>(i) * 0.5f) * 30.0f;
+            float x = fromLeft ? baseX - xOffset : baseX + xOffset;
+            float y = baseY + yOffset;
             fish->setPosition(x, y);
             fish->setDirection(fromLeft ? 1.0f : -1.0f, 0.0f);
             fish->setWindowBounds(getGame().getWindow().getSize());
             fish->initializeSprite(getGame().getSpriteManager());
-            return fish;
-            });
+
+            school.push_back(fish.get());
+            m_entities.push_back(std::move(fish));
+        }
+
+        m_fishSchools.push_back(std::move(school));
     }
 
     void BonusStageState::spawnPredatorWave()


### PR DESCRIPTION
## Summary
- spawn small fish in groups during the Feeding Frenzy bonus stage
- keep track of fish schools and update their flocking behaviour
- shorten Feeding Frenzy duration to 15 seconds

## Testing
- `cmake ..` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685b183be8688333ab572302fa0e76ce