### PR TITLE
Fix duplicate AnimatedSprite rotation methods

### DIFF
--- a/src/Utils/AnimatedSprite.cpp
+++ b/src/Utils/AnimatedSprite.cpp
@@ -55,15 +55,6 @@ void AnimatedSprite::setPosition(const sf::Vector2f& pos)
     m_sprite.setPosition(pos);
 }
 
-void AnimatedSprite::setRotation(float angle)
-{
-    m_sprite.setRotation(angle);
-}
-
-float AnimatedSprite::getRotation() const
-{
-    return m_sprite.getRotation();
-}
 
 void AnimatedSprite::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {


### PR DESCRIPTION
## Summary
- remove duplicate definitions of `setRotation` and `getRotation`

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685b1da478148333964b107bd1e15972