### PR TITLE
Improve state management lookup

### DIFF
--- a/include/Core/Game.h
+++ b/include/Core/Game.h
@@ -2,7 +2,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <memory>
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <functional>
 #include <type_traits>
@@ -98,7 +98,7 @@ namespace FishGame
 
         std::vector<StatePtr> m_stateStack;
         std::vector<std::pair<StateAction, StateID>> m_pendingList;
-        std::map<StateID, StateFactory> m_stateFactories;
+        std::unordered_map<StateID, StateFactory> m_stateFactories;
 
         std::unique_ptr<SpriteManager> m_spriteManager;
 

--- a/include/Managers/FishSpawner.h
+++ b/include/Managers/FishSpawner.h
@@ -2,7 +2,7 @@
 
 #include "GenericFish.h"
 #include "GenericSpawner.h"
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <random>
 
@@ -49,9 +49,9 @@ namespace FishGame
         GenericSpawner<LargeFish> m_largeSpawner;
 
         // Configuration maps
-        std::map<int, SpawnConfig> m_smallFishConfig;
-        std::map<int, SpawnConfig> m_mediumFishConfig;
-        std::map<int, SpawnConfig> m_largeFishConfig;
+        std::unordered_map<int, SpawnConfig> m_smallFishConfig;
+        std::unordered_map<int, SpawnConfig> m_mediumFishConfig;
+        std::unordered_map<int, SpawnConfig> m_largeFishConfig;
 
         int m_currentLevel;
         std::mt19937 m_randomEngine;

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -30,6 +30,8 @@ namespace FishGame
 
         // Reserve capacity for better performance
         m_pendingList.reserve(10);
+        m_stateStack.reserve(10);
+        m_stateFactories.reserve(10);
 
         // Load resources
         m_fonts.load(Fonts::Main, "Regular.ttf");


### PR DESCRIPTION
## Summary
- switch state factory map to `unordered_map`
- optimize fish spawner config containers
- pre-reserve state containers

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*
- `cmake --build build` *(fails: No rule to make target `Makefile`)*

------
https://chatgpt.com/codex/tasks/task_e_685c69bec4a08333869459cff9ff52e2