### PR TITLE
Fix Barracuda eat animation

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -78,7 +78,7 @@ namespace FishGame
         void initializeSprite(SpriteManager& spriteManager);
         void initializeAnimation(SpriteManager& spriteManager);
         void updateVisualState();
-        void playEatAnimation();
+        virtual void playEatAnimation();
 
         // Base color for sprite
         void setBaseColor(const sf::Color& color);

--- a/include/Entities/SpecialFish.h
+++ b/include/Entities/SpecialFish.h
@@ -60,7 +60,7 @@ namespace FishGame
 
         void update(sf::Time deltaTime) override;
         void initializeSprite(SpriteManager& spriteManager);
-        void playEatAnimation();
+        void playEatAnimation() override;
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -126,6 +126,8 @@ namespace FishGame
         std::string eat = m_facingRight ? "eatRight" : "eatLeft";
         m_animator->play(eat);
         m_currentAnimation = eat;
+        m_eating = true;
+        m_eatTimer = sf::seconds(m_eatDuration);
     }
 
     void Barracuda::update(sf::Time deltaTime)


### PR DESCRIPTION
## Summary
- mark `Fish::playEatAnimation` as virtual
- override the method in `Barracuda` and properly update eating state

## Testing
- `cmake ..` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685c70649ab48333b3ec7b7194ef0f8b