### PR TITLE
Fix player death state

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -481,6 +481,8 @@ namespace FishGame
 
     void Player::die()
     {
+        // Mark the player as dead so update() ignores further actions
+        m_isAlive = false;
         m_position = sf::Vector2f(
             static_cast<float>(m_windowBounds.x) / 2.0f,
             static_cast<float>(m_windowBounds.y) / 2.0f);


### PR DESCRIPTION
## Summary
- mark player as not alive when dying

## Testing
- `cppcheck src`

------
https://chatgpt.com/codex/tasks/task_e_685c773c76408333bd35b966a8668987