### PR TITLE
Remove unused default durations from Fish

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -111,10 +111,6 @@ namespace FishGame
         bool m_isFrozen;
         sf::Vector2f m_velocityBeforeFreeze;
 
-        // State durations
-        static constexpr float m_defaultPoisonDuration = 5.0f;
-        static constexpr float m_defaultStunDuration = 1.0f;
-
         // Fleeing behavior
         bool m_isFleeing;
         float m_fleeSpeed;


### PR DESCRIPTION
## Summary
- clean up `Fish` by removing stale `m_defaultPoisonDuration` and `m_defaultStunDuration` constants

## Testing
- `cmake -S . -B build` *(fails: could not find package `SFML`)*

------
https://chatgpt.com/codex/tasks/task_e_685c7a1475c08333b64a2f53122944d4