### PR TITLE
Implement StageIntro state

### DIFF
--- a/include/Core/State.h
+++ b/include/Core/State.h
@@ -15,6 +15,7 @@ namespace FishGame
     {
         None,
         Intro,
+        StageIntro,
         Menu,
         Play,
         Pause,

--- a/include/Managers/SpriteManager.h
+++ b/include/Managers/SpriteManager.h
@@ -66,6 +66,7 @@ namespace FishGame
         , ExitHover
         , Intro1
         , Intro2
+        , StageIntro
         , Background = Background1
     };
 

--- a/include/States/StageIntroState.h
+++ b/include/States/StageIntroState.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "State.h"
+#include "GameConstants.h"
+#include "StateUtils.h"
+#include <vector>
+#include <string>
+
+namespace FishGame
+{
+    class StageIntroState;
+    template<> struct is_state<StageIntroState> : std::true_type {};
+
+    struct StageIntroConfig
+    {
+        int level = 1;
+        bool pushPlay = true;
+        static StageIntroConfig& getInstance()
+        {
+            static StageIntroConfig instance;
+            return instance;
+        }
+    };
+
+    class StageIntroState : public State
+    {
+    public:
+        explicit StageIntroState(Game& game);
+        ~StageIntroState() override = default;
+
+        static void configure(int level, bool pushPlay);
+
+        void handleEvent(const sf::Event& event) override;
+        bool update(sf::Time deltaTime) override;
+        void render() override;
+        void onActivate() override;
+
+    private:
+        struct Item
+        {
+            sf::Sprite sprite;
+            sf::Text text;
+        };
+
+        void setupItems();
+        void exitState();
+
+        sf::Sprite m_backgroundSprite;
+        std::vector<Item> m_items;
+        sf::Time m_elapsed;
+        int m_level;
+        bool m_pushPlay;
+        static constexpr float DISPLAY_TIME = 3.0f;
+    };
+}

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -6,6 +6,7 @@
 #include "GameOverState.h"
 #include "PauseState.h"
 #include "GameOptionsState.h"
+#include "StageIntroState.h"
 #include <algorithm>
 #include "GameExceptions.h"
 
@@ -218,6 +219,7 @@ namespace FishGame
         // Register all game states using template method
         registerState<IntroState>(StateID::Intro);
         registerState<MenuState>(StateID::Menu);
+        registerState<StageIntroState>(StateID::StageIntro);
         registerState<PlayState>(StateID::Play);
         // Register bonus stage
         m_stateFactories[StateID::BonusStage] = [this]() -> std::unique_ptr<State>

--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -61,7 +61,8 @@ namespace FishGame
         {TextureID::Exit, "Exit.png"},
         {TextureID::ExitHover, "ExitHover.png"},
         { TextureID::Intro1, "Intro1.png" },
-        {TextureID::Intro2, "Intro2.png"}
+        {TextureID::Intro2, "Intro2.png"},
+        {TextureID::StageIntro, "StageIntro.png"}
     };
 
     SpriteManager::SpriteManager(ResourceHolder<sf::Texture, TextureID>& textureHolder)

--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -1,5 +1,6 @@
 #include "MenuState.h"
 #include "Game.h"
+#include "StageIntroState.h"
 #include <cmath>
 #include <algorithm>
 #include <numeric>
@@ -44,8 +45,9 @@ namespace FishGame
         const std::array<std::tuple<TextureID, TextureID, MenuAction>, static_cast<size_t>(MenuOption::Count)> menuData = { {
             {TextureID::NewGame, TextureID::NewGameHover, [this]() {
                 deferAction([this]() {
+                    StageIntroState::configure(1, true);
                     requestStackPop();
-                    requestStackPush(StateID::Play);
+                    requestStackPush(StateID::StageIntro);
                 });
             }},
             {TextureID::GameOptions, TextureID::GameOptionsHover, [this]() {

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -5,6 +5,7 @@
 #include "ExtendedPowerUps.h"
 #include "GameOverState.h"
 #include "PauseState.h"
+#include "StageIntroState.h"
 #include <algorithm>
 #include <execution>
 #include <sstream>
@@ -975,6 +976,9 @@ namespace FishGame
 
         m_hud.messageText.setString("");
         m_bonusStageTriggered = false;
+
+        StageIntroState::configure(m_gameState.currentLevel, false);
+        deferAction([this]() { requestStackPush(StateID::StageIntro); });
     }
 
     void PlayState::resetLevel()


### PR DESCRIPTION
## Summary
- add `StageIntro` to `StateID`
- load StageIntro texture in `SpriteManager`
- implement `StageIntroState` for level intros
- register new state in `Game`
- show StageIntro before a new game or when advancing levels

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685c7d34736c833389a74c0f71754e45