### PR TITLE
Fix StageIntroState fish frame

### DIFF
--- a/include/States/StageIntroState.h
+++ b/include/States/StageIntroState.h
@@ -1,55 +1,52 @@
 #pragma once
 
-#include "State.h"
 #include "GameConstants.h"
+#include "State.h"
 #include "StateUtils.h"
-#include <vector>
 #include <string>
+#include <vector>
 
-namespace FishGame
-{
-    class StageIntroState;
-    template<> struct is_state<StageIntroState> : std::true_type {};
+namespace FishGame {
+enum class TextureID;
+class StageIntroState;
+template <> struct is_state<StageIntroState> : std::true_type {};
 
-    struct StageIntroConfig
-    {
-        int level = 1;
-        bool pushPlay = true;
-        static StageIntroConfig& getInstance()
-        {
-            static StageIntroConfig instance;
-            return instance;
-        }
-    };
+struct StageIntroConfig {
+  int level = 1;
+  bool pushPlay = true;
+  static StageIntroConfig &getInstance() {
+    static StageIntroConfig instance;
+    return instance;
+  }
+};
 
-    class StageIntroState : public State
-    {
-    public:
-        explicit StageIntroState(Game& game);
-        ~StageIntroState() override = default;
+class StageIntroState : public State {
+public:
+  explicit StageIntroState(Game &game);
+  ~StageIntroState() override = default;
 
-        static void configure(int level, bool pushPlay);
+  static void configure(int level, bool pushPlay);
 
-        void handleEvent(const sf::Event& event) override;
-        bool update(sf::Time deltaTime) override;
-        void render() override;
-        void onActivate() override;
+  void handleEvent(const sf::Event &event) override;
+  bool update(sf::Time deltaTime) override;
+  void render() override;
+  void onActivate() override;
 
-    private:
-        struct Item
-        {
-            sf::Sprite sprite;
-            sf::Text text;
-        };
+private:
+  struct Item {
+    sf::Sprite sprite;
+    sf::Text text;
+    TextureID tex{TextureID::Background1};
+  };
 
-        void setupItems();
-        void exitState();
+  void setupItems();
+  void exitState();
 
-        sf::Sprite m_backgroundSprite;
-        std::vector<Item> m_items;
-        sf::Time m_elapsed;
-        int m_level;
-        bool m_pushPlay;
-        static constexpr float DISPLAY_TIME = 3.0f;
-    };
-}
+  sf::Sprite m_backgroundSprite;
+  std::vector<Item> m_items;
+  sf::Time m_elapsed;
+  int m_level;
+  bool m_pushPlay;
+  static constexpr float DISPLAY_TIME = 3.0f;
+};
+} // namespace FishGame

--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -2,126 +2,137 @@
 #include "Game.h"
 #include <string>
 
-namespace FishGame
-{
-    StageIntroState::StageIntroState(Game& game)
-        : State(game)
-        , m_backgroundSprite()
-        , m_items()
-        , m_elapsed(sf::Time::Zero)
-        , m_level(StageIntroConfig::getInstance().level)
-        , m_pushPlay(StageIntroConfig::getInstance().pushPlay)
-    {
-    }
-
-    void StageIntroState::configure(int level, bool pushPlay)
-    {
-        auto& cfg = StageIntroConfig::getInstance();
-        cfg.level = level;
-        cfg.pushPlay = pushPlay;
-    }
-
-    void StageIntroState::onActivate()
-    {
-        auto& manager = getGame().getSpriteManager();
-        auto& window = getGame().getWindow();
-        m_backgroundSprite.setTexture(manager.getTexture(TextureID::StageIntro));
-        auto texSize = m_backgroundSprite.getTexture()->getSize();
-        m_backgroundSprite.setScale(
-            static_cast<float>(window.getSize().x) / texSize.x,
-            static_cast<float>(window.getSize().y) / texSize.y);
-
-        setupItems();
-        m_elapsed = sf::Time::Zero;
-    }
-
-    void StageIntroState::setupItems()
-    {
-        m_items.clear();
-        auto& manager = getGame().getSpriteManager();
-        auto& font = getGame().getFonts().get(Fonts::Main);
-
-        auto add = [&](TextureID tex, const std::string& str)
-        {
-            Item item;
-            item.sprite.setTexture(manager.getTexture(tex));
-            item.text.setFont(font);
-            item.text.setString(str);
-            item.text.setCharacterSize(28);
-            m_items.push_back(std::move(item));
-        };
-
-        switch (m_level)
-        {
-        case 1:
-            add(TextureID::SmallFish, "Eat small fish to grow");
-            add(TextureID::Starfish, "Collect starfish for points");
-            break;
-        case 2:
-            add(TextureID::MediumFish, "Medium fish now appear");
-            add(TextureID::PowerUpSpeedBoost, "Grab power-ups for bonuses");
-            break;
-        default:
-            add(TextureID::LargeFish, "Large fish roam the waters");
-            add(TextureID::PoisonFish, "Avoid poison fish!");
-            add(TextureID::PowerUpExtraLife, "Extra life may appear");
-            break;
-        }
-
-        float startY = 300.f;
-        float xLeft = 300.f;
-        float xText = 400.f;
-        for (std::size_t i = 0; i < m_items.size(); ++i)
-        {
-            auto& item = m_items[i];
-            sf::FloatRect b = item.sprite.getLocalBounds();
-            item.sprite.setOrigin(b.width / 2.f, b.height / 2.f);
-            item.sprite.setPosition(xLeft, startY + i * 80.f);
-            item.sprite.setScale(0.75f, 0.75f);
-
-            b = item.text.getLocalBounds();
-            item.text.setOrigin(0.f, b.height / 2.f);
-            item.text.setPosition(xText, startY + i * 80.f);
-        }
-    }
-
-    void StageIntroState::handleEvent(const sf::Event& event)
-    {
-        if (event.type == sf::Event::KeyPressed || event.type == sf::Event::MouseButtonPressed)
-        {
-            exitState();
-        }
-    }
-
-    bool StageIntroState::update(sf::Time deltaTime)
-    {
-        m_elapsed += deltaTime;
-        if (m_elapsed.asSeconds() >= DISPLAY_TIME)
-        {
-            exitState();
-        }
-
-        processDeferredActions();
-        return false;
-    }
-
-    void StageIntroState::exitState()
-    {
-        deferAction([this]() {
-            requestStackPop();
-            if (m_pushPlay)
-                requestStackPush(StateID::Play);
-        });
-    }
-
-    void StageIntroState::render()
-    {
-        auto& window = getGame().getWindow();
-        window.draw(m_backgroundSprite);
-        for (auto& item : m_items)
-        {
-            window.draw(item.sprite);
-            window.draw(item.text);
-        }
-    }
+namespace {
+sf::IntRect firstFrameRect(FishGame::TextureID id) {
+  using namespace FishGame;
+  switch (id) {
+  case TextureID::SmallFish:
+  case TextureID::PoisonFish:
+  case TextureID::Angelfish:
+    return {1, 1, 66, 44};
+  case TextureID::MediumFish:
+    return {1, 1, 172, 108};
+  case TextureID::LargeFish:
+    return {1, 1, 201, 148};
+  default:
+    return {};
+  }
 }
+} // namespace
+
+namespace FishGame {
+StageIntroState::StageIntroState(Game &game)
+    : State(game), m_backgroundSprite(), m_items(), m_elapsed(sf::Time::Zero),
+      m_level(StageIntroConfig::getInstance().level),
+      m_pushPlay(StageIntroConfig::getInstance().pushPlay) {}
+
+void StageIntroState::configure(int level, bool pushPlay) {
+  auto &cfg = StageIntroConfig::getInstance();
+  cfg.level = level;
+  cfg.pushPlay = pushPlay;
+}
+
+void StageIntroState::onActivate() {
+  auto &manager = getGame().getSpriteManager();
+  auto &window = getGame().getWindow();
+  m_backgroundSprite.setTexture(manager.getTexture(TextureID::StageIntro));
+  auto texSize = m_backgroundSprite.getTexture()->getSize();
+  m_backgroundSprite.setScale(
+      static_cast<float>(window.getSize().x) / texSize.x,
+      static_cast<float>(window.getSize().y) / texSize.y);
+
+  setupItems();
+  m_elapsed = sf::Time::Zero;
+}
+
+void StageIntroState::setupItems() {
+  m_items.clear();
+  auto &manager = getGame().getSpriteManager();
+  auto &font = getGame().getFonts().get(Fonts::Main);
+
+  auto add = [&](TextureID tex, const std::string &str) {
+    Item item;
+    item.tex = tex;
+    item.sprite.setTexture(manager.getTexture(tex));
+    item.text.setFont(font);
+    item.text.setString(str);
+    item.text.setCharacterSize(28);
+    m_items.push_back(std::move(item));
+  };
+
+  switch (m_level) {
+  case 1:
+    add(TextureID::SmallFish, "Eat small fish to grow");
+    add(TextureID::Starfish, "Collect starfish for points");
+    break;
+  case 2:
+    add(TextureID::MediumFish, "Medium fish now appear");
+    add(TextureID::PowerUpSpeedBoost, "Grab power-ups for bonuses");
+    break;
+  default:
+    add(TextureID::LargeFish, "Large fish roam the waters");
+    add(TextureID::PoisonFish, "Avoid poison fish!");
+    add(TextureID::PowerUpExtraLife, "Extra life may appear");
+    break;
+  }
+
+  float startY = 300.f;
+  float xLeft = 300.f;
+  float xText = 400.f;
+  for (std::size_t i = 0; i < m_items.size(); ++i) {
+    auto &item = m_items[i];
+
+    // Display only the first frame of the sprite sheet for fish
+    sf::IntRect rect = firstFrameRect(item.tex);
+    if (rect.width > 0)
+      item.sprite.setTextureRect(rect);
+
+    sf::FloatRect b = item.sprite.getLocalBounds();
+    item.sprite.setOrigin(b.width / 2.f, b.height / 2.f);
+    item.sprite.setPosition(xLeft, startY + i * 80.f);
+
+    float scale = 0.75f;
+    if (item.tex == TextureID::Starfish)
+      scale = 0.25f;
+    item.sprite.setScale(scale, scale);
+
+    b = item.text.getLocalBounds();
+    item.text.setOrigin(0.f, b.height / 2.f);
+    item.text.setPosition(xText, startY + i * 80.f);
+  }
+}
+
+void StageIntroState::handleEvent(const sf::Event &event) {
+  if (event.type == sf::Event::KeyPressed ||
+      event.type == sf::Event::MouseButtonPressed) {
+    exitState();
+  }
+}
+
+bool StageIntroState::update(sf::Time deltaTime) {
+  m_elapsed += deltaTime;
+  if (m_elapsed.asSeconds() >= DISPLAY_TIME) {
+    exitState();
+  }
+
+  processDeferredActions();
+  return false;
+}
+
+void StageIntroState::exitState() {
+  deferAction([this]() {
+    requestStackPop();
+    if (m_pushPlay)
+      requestStackPush(StateID::Play);
+  });
+}
+
+void StageIntroState::render() {
+  auto &window = getGame().getWindow();
+  window.draw(m_backgroundSprite);
+  for (auto &item : m_items) {
+    window.draw(item.sprite);
+    window.draw(item.text);
+  }
+}
+} // namespace FishGame


### PR DESCRIPTION
## Summary
- set up item struct to store `TextureID`
- show only first frame for fish sprites in StageIntroState
- shrink starfish sprite during stage intro

## Testing
- `cmake -S . -B build` *(fails: FindSFML.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2c4c5bd88333b91c961620316728