### PR TITLE
Fix TextureID compilation

### DIFF
--- a/include/States/StageIntroState.h
+++ b/include/States/StageIntroState.h
@@ -3,6 +3,7 @@
 #include "GameConstants.h"
 #include "State.h"
 #include "StateUtils.h"
+#include "Managers/SpriteManager.h"
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- include `SpriteManager` in `StageIntroState` header so enum values are available

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/oop2_project` *(fails: Failed to open X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_685d2eb05b30833391ca204a7e5d9092