### PR TITLE
Add stage instructions and bonus level hints

### DIFF
--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -97,6 +97,7 @@ namespace FishGame
         sf::Text m_objectiveText;
         sf::Text m_timerText;
         sf::Text m_scoreText;
+        sf::Text m_instructionText;
         sf::RectangleShape m_timerBar;
         sf::RectangleShape m_timerBackground;
 
@@ -107,6 +108,9 @@ namespace FishGame
 
         sf::Time m_timePowerUpTimer{ sf::Time::Zero };
 
+        sf::Time m_instructionTimer{ sf::Time::Zero };
+        bool m_showInstructions{ false };
+
         // Short grace period after collecting a pearl to avoid instant failure
         sf::Time m_oysterSafetyTimer{ sf::Time::Zero };
 
@@ -115,5 +119,6 @@ namespace FishGame
         static constexpr float m_treasureHuntDuration = 30.0f;
         static constexpr float m_feedingFrenzyDuration = 15.0f;
         static constexpr float m_survivalDuration = 60.0f;
+        static constexpr float m_instructionDuration = 5.0f;
     };
 }

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -61,6 +61,10 @@ namespace FishGame
         m_scoreText.setFillColor(sf::Color::Green);
         m_scoreText.setPosition(50.0f, 150.0f);
 
+        m_instructionText.setFont(font);
+        m_instructionText.setCharacterSize(30);
+        m_instructionText.setFillColor(sf::Color::White);
+
         // Background image for bonus stage
         auto& window = getGame().getWindow();
         m_backgroundSprite.setTexture(
@@ -172,6 +176,15 @@ namespace FishGame
         if (m_oysterSafetyTimer > sf::Time::Zero)
         {
             m_oysterSafetyTimer -= deltaTime;
+        }
+
+        if (m_showInstructions)
+        {
+            m_instructionTimer += deltaTime;
+            if (m_instructionTimer.asSeconds() > m_instructionDuration)
+            {
+                m_showInstructions = false;
+            }
         }
 
         // Update entities
@@ -318,6 +331,9 @@ namespace FishGame
         window.draw(m_timerBackground);
         window.draw(m_timerBar);
 
+        if (m_showInstructions)
+            window.draw(m_instructionText);
+
         // Draw completion message
         if (m_stageComplete)
         {
@@ -358,6 +374,24 @@ namespace FishGame
         objStream << m_objective.description << " (" << m_objective.currentCount
             << "/" << m_objective.targetCount << ")";
         m_objectiveText.setString(objStream.str());
+
+        m_showInstructions = true;
+        m_instructionTimer = sf::Time::Zero;
+        if (m_stageType == BonusStageType::FeedingFrenzy)
+        {
+            m_instructionText.setString(
+                "Eat small fish and starfish! Avoid bombs.\nGrab time power-ups for more time.");
+        }
+        else
+        {
+            m_instructionText.setString(
+                "Complete the objective before time runs out!");
+        }
+
+        sf::FloatRect b = m_instructionText.getLocalBounds();
+        m_instructionText.setOrigin(b.width / 2.f, b.height / 2.f);
+        auto win = getGame().getWindow().getSize();
+        m_instructionText.setPosition(win.x / 2.f, win.y - 60.f);
     }
 
     void BonusStageState::updateTreasureHunt(sf::Time deltaTime)

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -1298,6 +1298,8 @@ void PlayState::centerText(sf::Text& text)
 
             m_hud.messageText.setString("");
             m_initialized = true;
+            StageIntroState::configure(m_gameState.currentLevel, false);
+            deferAction([this]() { requestStackPush(StateID::StageIntro); });
         }
         else if (!m_initialized)
         {

--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -100,7 +100,15 @@ void StageIntroState::setupItems() {
   case 3:
     add(TextureID::PoisonFish, "Avoid poison fish!");
     add(TextureID::Angelfish, "Eat angelfish to grow to next staage");
-	break;
+    break;
+  case 4:
+    add(TextureID::Pufferfish, "Pufferfish inflates when threatened");
+    add(TextureID::PufferfishInflated, "Avoid it while puffed!");
+    add(TextureID::Jellyfish, "Jellyfish will stun you");
+    break;
+  case 5:
+    add(TextureID::Barracuda, "Barracuda is fast and dangerous");
+    break;
   default:
     
     add(TextureID::PoisonFish, "Avoid poison fish!");


### PR DESCRIPTION
## Summary
- show new tutorial items for levels 4 and 5
- display instructions at start of bonus levels
- restore stage intro when returning from bonus stage

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685d41542d8c8333b9e2bb761497f0ff