### PR TITLE
Add bonus stage intro instructions

### DIFF
--- a/include/States/StageIntroState.h
+++ b/include/States/StageIntroState.h
@@ -14,7 +14,9 @@ template <> struct is_state<StageIntroState> : std::true_type {};
 
 struct StageIntroConfig {
   int level = 1;
-  bool pushPlay = true;
+  bool pushNext = true;
+  StateID nextState = StateID::Play;
+
   static StageIntroConfig &getInstance() {
     static StageIntroConfig instance;
     return instance;
@@ -26,7 +28,8 @@ public:
   explicit StageIntroState(Game &game);
   ~StageIntroState() override = default;
 
-  static void configure(int level, bool pushPlay);
+  static void configure(int level, bool pushNext,
+                        StateID nextState = StateID::Play);
 
   void handleEvent(const sf::Event &event) override;
   bool update(sf::Time deltaTime) override;
@@ -49,6 +52,7 @@ private:
   sf::Time m_elapsed;
   int m_level;
   bool m_pushPlay;
+  StateID m_nextState;
   static constexpr float DISPLAY_TIME = 3.0f;
 };
 } // namespace FishGame

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -1062,7 +1062,8 @@ namespace FishGame
 
                 deferAction([this, bonusType]() {
                     m_returningFromBonusStage = true;
-                    requestStackPush(StateID::BonusStage);
+                    StageIntroState::configure(0, true, StateID::BonusStage);
+                    requestStackPush(StateID::StageIntro);
                     });
             }
         }

--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -39,12 +39,14 @@ namespace FishGame {
 StageIntroState::StageIntroState(Game &game)
     : State(game), m_backgroundSprite(), m_overlaySprite(), m_items(), m_elapsed(sf::Time::Zero),
       m_level(StageIntroConfig::getInstance().level),
-      m_pushPlay(StageIntroConfig::getInstance().pushPlay) {}
+      m_pushPlay(StageIntroConfig::getInstance().pushNext),
+      m_nextState(StageIntroConfig::getInstance().nextState) {}
 
-void StageIntroState::configure(int level, bool pushPlay) {
+void StageIntroState::configure(int level, bool pushNext, StateID nextState) {
   auto &cfg = StageIntroConfig::getInstance();
   cfg.level = level;
-  cfg.pushPlay = pushPlay;
+  cfg.pushNext = pushNext;
+  cfg.nextState = nextState;
 }
 
 void StageIntroState::onActivate() {
@@ -83,6 +85,12 @@ void StageIntroState::setupItems() {
   };
 
   switch (m_level) {
+  case 0:
+    add(TextureID::Bomb, "Avoid bombs!");
+    add(TextureID::SmallFish, "Eat small fish for points");
+    add(TextureID::Starfish, "Collect starfish for points");
+    add(TextureID::PowerUpAddTime, "Grab time power-ups to extend time");
+    break;
   case 1:
     add(TextureID::SmallFish, "Eat small fish to grow");
     add(TextureID::MediumFish, "Eat Medium fish to become the king of the stage!");
@@ -157,7 +165,7 @@ void StageIntroState::exitState() {
   deferAction([this]() {
     requestStackPop();
     if (m_pushPlay)
-      requestStackPush(StateID::Play);
+      requestStackPush(m_nextState);
   });
 }
 


### PR DESCRIPTION
## Summary
- allow `StageIntroState` to push an arbitrary next state
- show instructions for the bonus stage
- push `StageIntroState` before entering the bonus level

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685d47ffcb008333a03195e5433364e5