### PR TITLE
Implement camera follow for bonus stage

### DIFF
--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -64,6 +64,9 @@ namespace FishGame
         void completeStage();
         int calculateBonus() const;
 
+        // Camera handling
+        void updateCamera();
+
         // Template helper for spawning entities
         template<typename EntityType, typename... Args>
         void spawnEntity(std::vector<std::unique_ptr<Entity>>& container,
@@ -120,5 +123,10 @@ namespace FishGame
         static constexpr float m_feedingFrenzyDuration = 15.0f;
         static constexpr float m_survivalDuration = 60.0f;
         static constexpr float m_instructionDuration = 5.0f;
+
+        // Camera and world
+        sf::View m_view{};
+        sf::Vector2f m_worldSize{};
+        static constexpr float m_cameraSmoothing = 0.1f;
     };
 }


### PR DESCRIPTION
## Summary
- add camera view and update logic to `BonusStageState`
- center camera on activation and follow player while updating
- render bonus stage using the zoomed view

## Testing
- `cmake -B build -S .` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685d4dbbd138833385f8cdc2c420c041