### PR TITLE
Add stage summary screen

### DIFF
--- a/include/Core/State.h
+++ b/include/Core/State.h
@@ -16,6 +16,7 @@ namespace FishGame
         None,
         Intro,
         StageIntro,
+        StageSummary,
         Menu,
         Play,
         Pause,

--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -28,6 +28,7 @@
 
 namespace FishGame
 {
+    enum class TextureID;
     // Template trait specialization
     class PlayState;
     template<> struct is_state<PlayState> : std::true_type {};
@@ -197,6 +198,7 @@ namespace FishGame
         // State tracking
         GameStateData m_gameState;
         HUDElements m_hud;
+        std::unordered_map<TextureID, int> m_levelCounts;
 
         // Effect states
         bool m_isPlayerFrozen;

--- a/include/States/StageSummaryState.h
+++ b/include/States/StageSummaryState.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "State.h"
+#include "StateUtils.h"
+#include "GameConstants.h"
+#include "Managers/SpriteManager.h"
+#include <unordered_map>
+#include <vector>
+
+namespace FishGame {
+class StageIntroState;
+
+class StageSummaryState;
+template<> struct is_state<StageSummaryState> : std::true_type {};
+
+struct StageSummaryConfig {
+    int nextLevel = 1;
+    int levelScore = 0;
+    std::unordered_map<TextureID, int> counts;
+    static StageSummaryConfig& getInstance() {
+        static StageSummaryConfig instance;
+        return instance;
+    }
+};
+
+class StageSummaryState : public State {
+public:
+    explicit StageSummaryState(Game& game);
+    ~StageSummaryState() override = default;
+
+    static void configure(int nextLevel, int levelScore,
+                          const std::unordered_map<TextureID, int>& counts);
+
+    void handleEvent(const sf::Event& event) override;
+    bool update(sf::Time deltaTime) override;
+    void render() override;
+    void onActivate() override;
+
+private:
+    struct Item {
+        sf::Sprite sprite;
+        sf::Text text;
+    };
+
+    void setupItems();
+    void exitState();
+
+    sf::Sprite m_overlaySprite;
+    sf::Text m_scoreText;
+    sf::Text m_nextText;
+    std::vector<Item> m_items;
+};
+} // namespace FishGame

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -7,6 +7,7 @@
 #include "PauseState.h"
 #include "GameOptionsState.h"
 #include "StageIntroState.h"
+#include "StageSummaryState.h"
 #include <algorithm>
 #include "GameExceptions.h"
 
@@ -220,6 +221,7 @@ namespace FishGame
         registerState<IntroState>(StateID::Intro);
         registerState<MenuState>(StateID::Menu);
         registerState<StageIntroState>(StateID::StageIntro);
+        registerState<StageSummaryState>(StateID::StageSummary);
         registerState<PlayState>(StateID::Play);
         // Register bonus stage
         m_stateFactories[StateID::BonusStage] = [this]() -> std::unique_ptr<State>

--- a/src/States/StageSummaryState.cpp
+++ b/src/States/StageSummaryState.cpp
@@ -1,0 +1,146 @@
+#include "StageSummaryState.h"
+#include "Game.h"
+#include "StageIntroState.h"
+
+namespace {
+using FishGame::TextureID;
+
+sf::IntRect firstFrameRect(TextureID id) {
+    using namespace FishGame;
+    switch (id) {
+    case TextureID::SmallFish:
+    case TextureID::PoisonFish:
+    case TextureID::Angelfish:
+        return {1,1,66,44};
+    case TextureID::MediumFish:
+        return {1,1,172,108};
+    case TextureID::LargeFish:
+        return {1,1,201,148};
+    case TextureID::PearlOysterClosed:
+        return {1,1,101,101};
+    case TextureID::PearlOysterOpen:
+        return {1+4*101,1,101,101};
+    case TextureID::Bomb:
+        return {1,1,69,69};
+    case TextureID::Pufferfish:
+        return {5,5,187,131};
+    case TextureID::PufferfishInflated:
+        return {5,136,186,169};
+    case TextureID::Jellyfish:
+        return {1,1,75,197};
+    case TextureID::Barracuda:
+        return {1,1,270,122};
+    default:
+        return {};
+    }
+}
+}
+
+namespace FishGame {
+StageSummaryState::StageSummaryState(Game& game)
+    : State(game), m_overlaySprite(), m_scoreText(), m_nextText(), m_items() {}
+
+void StageSummaryState::configure(int nextLevel, int levelScore,
+                                  const std::unordered_map<TextureID, int>& counts) {
+    auto& cfg = StageSummaryConfig::getInstance();
+    cfg.nextLevel = nextLevel;
+    cfg.levelScore = levelScore;
+    cfg.counts = counts;
+}
+
+void StageSummaryState::onActivate() {
+    auto& manager = getGame().getSpriteManager();
+    auto& window = getGame().getWindow();
+    m_overlaySprite.setTexture(manager.getTexture(TextureID::StageIntro));
+    auto size = m_overlaySprite.getTexture()->getSize();
+    m_overlaySprite.setScale(static_cast<float>(window.getSize().x)/size.x,
+                             static_cast<float>(window.getSize().y)/size.y);
+
+    auto& font = getGame().getFonts().get(Fonts::Main);
+    m_scoreText.setFont(font);
+    m_scoreText.setCharacterSize(48);
+    m_scoreText.setFillColor(sf::Color::White);
+    m_scoreText.setString("Score: " + std::to_string(StageSummaryConfig::getInstance().levelScore));
+    auto bounds = m_scoreText.getLocalBounds();
+    m_scoreText.setOrigin(bounds.width/2.f, bounds.height/2.f);
+    m_scoreText.setPosition(window.getSize().x/2.f, 150.f);
+
+    m_nextText.setFont(font);
+    m_nextText.setString("Next");
+    m_nextText.setCharacterSize(36);
+    auto nb = m_nextText.getLocalBounds();
+    m_nextText.setOrigin(nb.width/2.f, nb.height/2.f);
+    m_nextText.setPosition(window.getSize().x/2.f, window.getSize().y - 120.f);
+
+    setupItems();
+}
+
+void StageSummaryState::setupItems() {
+    m_items.clear();
+    auto& cfg = StageSummaryConfig::getInstance();
+    auto& manager = getGame().getSpriteManager();
+    auto& font = getGame().getFonts().get(Fonts::Main);
+
+    float startY = 250.f;
+    float spacing = 80.f;
+    float spriteX = getGame().getWindow().getSize().x/2.f - 100.f;
+    float textX = getGame().getWindow().getSize().x/2.f + 60.f;
+
+    int index = 0;
+    for (const auto& kv : cfg.counts) {
+        Item item;
+        item.sprite.setTexture(manager.getTexture(kv.first));
+        sf::IntRect rect = firstFrameRect(kv.first);
+        if (rect.width > 0) item.sprite.setTextureRect(rect);
+        auto b = item.sprite.getLocalBounds();
+        item.sprite.setOrigin(b.width/2.f, b.height/2.f);
+        item.sprite.setPosition(spriteX, startY + spacing*index);
+        item.sprite.setScale(0.5f, 0.5f);
+
+        item.text.setFont(font);
+        item.text.setString(std::to_string(kv.second));
+        auto tb = item.text.getLocalBounds();
+        item.text.setOrigin(tb.width/2.f, tb.height/2.f);
+        item.text.setPosition(textX, startY + spacing*index);
+        item.text.setCharacterSize(32);
+        m_items.push_back(std::move(item));
+        ++index;
+    }
+}
+
+void StageSummaryState::handleEvent(const sf::Event& event) {
+    if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Enter) {
+        exitState();
+    } else if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Left) {
+        sf::Vector2f pos(static_cast<float>(event.mouseButton.x), static_cast<float>(event.mouseButton.y));
+        if (m_nextText.getGlobalBounds().contains(pos)) {
+            exitState();
+        }
+    }
+}
+
+bool StageSummaryState::update(sf::Time) {
+    processDeferredActions();
+    return false;
+}
+
+void StageSummaryState::exitState() {
+    deferAction([this]() {
+        requestStackPop();
+        StageIntroState::configure(StageSummaryConfig::getInstance().nextLevel, false);
+        requestStackPush(StateID::StageIntro);
+    });
+}
+
+void StageSummaryState::render() {
+    auto& window = getGame().getWindow();
+    window.draw(m_overlaySprite);
+    window.draw(m_scoreText);
+    for (auto& item : m_items) {
+        window.draw(item.sprite);
+        window.draw(item.text);
+    }
+    window.draw(m_nextText);
+}
+
+} // namespace FishGame


### PR DESCRIPTION
## Summary
- introduce `StageSummaryState` to show counts per item after each level
- track eaten fish and starfish in `PlayState`
- push `StageSummaryState` before next stage starts
- register state and add new `StateID`

## Testing
- `cmake` configuration fails due to missing SFML

------
https://chatgpt.com/codex/tasks/task_e_685d6d58e47c8333a4112799fe13ae02