### PR TITLE
Implement fish collection tracking

### DIFF
--- a/include/Systems/ScoreSystem.h
+++ b/include/Systems/ScoreSystem.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 #include <cmath>
+#include <unordered_map>
+#include "Managers/SpriteManager.h"
 
 namespace FishGame
 {
@@ -71,6 +73,8 @@ namespace FishGame
         // Score tracking
         int getCurrentScore() const { return m_currentScore; }
         void setCurrentScore(int score) { m_currentScore = score; }
+        void recordFish(TextureID id);
+        const std::unordered_map<TextureID,int>& getFishCounts() const { return m_fishCounts; }
         void reset();
 
     private:
@@ -88,6 +92,9 @@ namespace FishGame
 
         // Visual elements
         std::vector<std::unique_ptr<FloatingScore>> m_floatingScores;
+
+        // Fish counts
+        std::unordered_map<TextureID,int> m_fishCounts;
 
         // Bonus values
         static constexpr int m_tailBiteBonus = 75;

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -383,6 +383,7 @@ namespace FishGame
 
                 m_scoreSystem->addScore(ScoreEventType::FishEaten, fish->getPointValue(),
                     other.getPosition(), frenzyMultiplier, powerUpMultiplier);
+                m_scoreSystem->recordFish(fish->getTextureID());
             }
 
             if (m_frenzySystem)

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -777,6 +777,7 @@ namespace FishGame
             if (item.getBonusType() == BonusType::Starfish)
             {
                 state->m_levelCounts[TextureID::Starfish]++;
+                state->m_scoreSystem->recordFish(TextureID::Starfish);
             }
             int frenzyMultiplier = state->m_frenzySystem->getMultiplier();
             float powerUpMultiplier = state->m_powerUpManager->getScoreMultiplier();

--- a/src/Systems/ScoreSystem.cpp
+++ b/src/Systems/ScoreSystem.cpp
@@ -91,6 +91,7 @@ namespace FishGame
         , m_currentScore(0)
         , m_currentChain(0)
         , m_floatingScores()
+        , m_fishCounts()
     {
         m_floatingScores.reserve(20);
     }
@@ -133,6 +134,11 @@ namespace FishGame
         m_currentChain = 0;
     }
 
+    void ScoreSystem::recordFish(TextureID id)
+    {
+        ++m_fishCounts[id];
+    }
+
     void ScoreSystem::registerTailBite(sf::Vector2f position, int frenzyMultiplier, float powerUpMultiplier)
     {
         addScore(ScoreEventType::TailBite, m_tailBiteBonus, position, frenzyMultiplier, powerUpMultiplier);
@@ -169,6 +175,7 @@ namespace FishGame
         m_currentScore = 0;
         m_currentChain = 0;
         m_floatingScores.clear();
+        m_fishCounts.clear();
     }
 
     void ScoreSystem::createFloatingScore(int points, int multiplier, sf::Vector2f position)


### PR DESCRIPTION
## Summary
- add unordered_map of fish counts to `ScoreSystem`
- track each fish texture consumed or collected
- record starfish bonus pickups in `BonusItemCollisionHandler`
- report collected fish via new getter

## Testing
- `cmake -B build` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685d73ded1c88333ad44d36b04514ab7