### PR TITLE
Add fish counts to level summary

### DIFF
--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -967,7 +967,9 @@ namespace FishGame
     void PlayState::advanceLevel()
     {
         int levelScore = m_scoreSystem->getCurrentScore();
-        StageSummaryState::configure(m_gameState.currentLevel + 1, levelScore, m_levelCounts);
+        const auto& fishCounts = m_scoreSystem->getFishCounts();
+        StageSummaryState::configure(m_gameState.currentLevel + 1,
+                                     levelScore, fishCounts);
         m_levelCounts.clear();
 
         m_gameState.currentLevel++;


### PR DESCRIPTION
## Summary
- collect fish counts from ScoreSystem before resetting level
- forward counts to StageSummaryState

## Testing
- `cmake -B build -S .` *(fails: missing SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685d7b2deb8083339edd6e0e78bfe859