### PR TITLE
Fix access to getTextureID

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -84,15 +84,15 @@ namespace FishGame
         void setBaseColor(const sf::Color& color);
         const sf::Color& getBaseColor() const { return m_baseColor; }
 
+        // Get appropriate texture ID for this fish
+        virtual TextureID getTextureID() const;
+
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
         void updateMovement(sf::Time deltaTime);
 
         // Sprite-specific updates
         virtual void updateSpriteEffects(sf::Time deltaTime);
-
-        // Get appropriate texture ID for this fish
-        virtual TextureID getTextureID() const;
 
     protected:
         FishSize m_size;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -708,7 +708,7 @@ namespace FishGame
             {
                 if (state->m_player->attemptEat(fish))
                 {
-                    state->m_levelCounts[fish.getTextureID()]++;
+                    state->m_levelCounts[puffer->getTextureID()]++;
                     fish.destroy();
                     state->createParticleEffect(fish.getPosition(), Constants::EAT_PARTICLE_COLOR);
                 }
@@ -720,11 +720,11 @@ namespace FishGame
                 state->handlePlayerDeath();
             }
         }
-        else if (dynamic_cast<Angelfish*>(&fish))
+        else if (auto* angelfish = dynamic_cast<Angelfish*>(&fish))
         {
             if (state->m_player->canEat(fish) && state->m_player->attemptEat(fish))
             {
-                state->m_levelCounts[fish.getTextureID()]++;
+                state->m_levelCounts[angelfish->getTextureID()]++;
                 state->createParticleEffect(fish.getPosition(),
                     Constants::ANGELFISH_PARTICLE_COLOR, Constants::ANGELFISH_PARTICLE_COUNT);
                 fish.destroy();
@@ -739,7 +739,7 @@ namespace FishGame
                 state->m_player->applyPoisonEffect(poison->getPoisonDuration());
                 state->createParticleEffect(fish.getPosition(), sf::Color::Magenta, 15);
                 state->createParticleEffect(state->m_player->getPosition(), sf::Color::Magenta, 10);
-                state->m_levelCounts[fish.getTextureID()]++;
+                state->m_levelCounts[poison->getTextureID()]++;
                 fish.destroy();
             }
         }
@@ -750,7 +750,7 @@ namespace FishGame
 
             if (playerCanEat && state->m_player->attemptEat(fish))
             {
-                state->m_levelCounts[fish.getTextureID()]++;
+                state->m_levelCounts[regularFish->getTextureID()]++;
                 fish.destroy();
                 state->createParticleEffect(fish.getPosition(), Constants::EAT_PARTICLE_COLOR);
             }


### PR DESCRIPTION
## Summary
- make `Fish::getTextureID` a public method
- use derived pointers when recording fish counts

## Testing
- `cmake -B build -S .`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685d7d15aa2883339ad9b57c10e73a6f