### PR TITLE
Adjust starfish scale on summary screen

### DIFF
--- a/src/States/StageSummaryState.cpp
+++ b/src/States/StageSummaryState.cpp
@@ -95,7 +95,11 @@ void StageSummaryState::setupItems() {
         auto b = item.sprite.getLocalBounds();
         item.sprite.setOrigin(b.width/2.f, b.height/2.f);
         item.sprite.setPosition(spriteX, startY + spacing*index);
-        item.sprite.setScale(0.5f, 0.5f);
+
+        float scale = 0.5f;
+        if (kv.first == TextureID::Starfish)
+            scale = 0.02f;
+        item.sprite.setScale(scale, scale);
 
         item.text.setFont(font);
         item.text.setString(std::to_string(kv.second));


### PR DESCRIPTION
## Summary
- update `StageSummaryState` so starfish sprites render much smaller on the summary screen

## Testing
- `cmake ..`
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_685d826785908333bbea4251108c372d