### PR TITLE
Add music support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,13 @@ if (WIN32)
     set (SFML_DIR "${SFML_LOCATION}/lib/cmake/SFML")
 endif()
 
-find_package (SFML 2.6 COMPONENTS graphics REQUIRED)
+find_package (SFML 2.6 COMPONENTS graphics audio REQUIRED)
 
 if (WIN32)
     set_target_properties (sfml-main sfml-system sfml-window sfml-graphics sfml-audio sfml-network PROPERTIES MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)
-    target_link_libraries (${CMAKE_PROJECT_NAME} sfml-graphics sfml-main)
+    target_link_libraries (${CMAKE_PROJECT_NAME} sfml-graphics sfml-audio sfml-main)
     include (cmake/SFML.cmake)
 else()
-    target_link_libraries (${CMAKE_PROJECT_NAME} sfml-graphics pthread)
+    target_link_libraries (${CMAKE_PROJECT_NAME} sfml-graphics sfml-audio pthread)
 endif()
 

--- a/include/Core/Game.h
+++ b/include/Core/Game.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <type_traits>
 #include "ResourceHolder.h"
+#include "MusicPlayer.h"
 #include "State.h"
 #include "Player.h"
 #include "GameConstants.h"
@@ -32,6 +33,8 @@ namespace FishGame
         const sf::RenderWindow& getWindow() const { return m_window; }
         FontHolder& getFonts() { return m_fonts; }
         SpriteManager& getSpriteManager() { return *m_spriteManager; }
+        MusicPlayer& getMusicPlayer() { return *m_musicPlayer; }
+        const MusicPlayer& getMusicPlayer() const { return *m_musicPlayer; }
 
         // State management
         void pushState(StateID id);
@@ -101,6 +104,7 @@ namespace FishGame
         std::unordered_map<StateID, StateFactory> m_stateFactories;
 
         std::unique_ptr<SpriteManager> m_spriteManager;
+        std::unique_ptr<MusicPlayer> m_musicPlayer;
 
         // Performance tracking
         struct PerformanceMetrics

--- a/include/Core/MusicPlayer.h
+++ b/include/Core/MusicPlayer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <SFML/Audio.hpp>
+#include <map>
+#include <string>
+
+namespace FishGame {
+
+enum class MusicID {
+    MenuTheme,
+    InGame1,
+    InGame2,
+    InGame3,
+    BonusStage,
+    InstructionsHelp,
+    ScoreSummary,
+    StageCleared,
+    PlayerDies
+};
+
+class MusicPlayer {
+public:
+    MusicPlayer();
+
+    void play(MusicID theme, bool loop = true);
+    void stop();
+    void setVolume(float volume);
+
+private:
+    sf::Music m_music;
+    std::map<MusicID, std::string> m_filenames;
+    float m_volume;
+};
+
+}

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -8,6 +8,7 @@
 #include "GameOptionsState.h"
 #include "StageIntroState.h"
 #include "StageSummaryState.h"
+#include "MusicPlayer.h"
 #include <algorithm>
 #include "GameExceptions.h"
 
@@ -26,6 +27,7 @@ namespace FishGame
         , m_pendingList()
         , m_stateFactories()
         , m_spriteManager(nullptr)
+        , m_musicPlayer(std::make_unique<MusicPlayer>())
         , m_metrics()
     {
         m_window.setFramerateLimit(m_frameRateLimit);

--- a/src/Core/MusicPlayer.cpp
+++ b/src/Core/MusicPlayer.cpp
@@ -1,0 +1,48 @@
+#include "MusicPlayer.h"
+#include "GameExceptions.h"
+
+namespace FishGame {
+
+MusicPlayer::MusicPlayer()
+    : m_music()
+    , m_filenames{
+        {MusicID::MenuTheme, "MenuTheme.ogg"},
+        {MusicID::InGame1, "InGame1.ogg"},
+        {MusicID::InGame2, "InGame2.ogg"},
+        {MusicID::InGame3, "InGame3.ogg"},
+        {MusicID::BonusStage, "BonusStage.ogg"},
+        {MusicID::InstructionsHelp, "InstructionsHelp.ogg"},
+        {MusicID::ScoreSummary, "ScoreSummary.ogg"},
+        {MusicID::StageCleared, "StageCleared.ogg"},
+        {MusicID::PlayerDies, "PlayerDies.ogg"}}
+    , m_volume(100.f)
+{}
+
+void MusicPlayer::play(MusicID theme, bool loop)
+{
+    auto it = m_filenames.find(theme);
+    if (it == m_filenames.end()) {
+        throw ResourceLoadException("Music ID not found");
+    }
+
+    if (!m_music.openFromFile(it->second)) {
+        throw ResourceLoadException("Failed to load music: " + it->second);
+    }
+
+    m_music.setLoop(loop);
+    m_music.setVolume(m_volume);
+    m_music.play();
+}
+
+void MusicPlayer::stop()
+{
+    m_music.stop();
+}
+
+void MusicPlayer::setVolume(float volume)
+{
+    m_volume = volume;
+    m_music.setVolume(m_volume);
+}
+
+} // namespace FishGame

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -9,6 +9,7 @@
 #include "Hazard.h"
 #include "FishCollisionHandler.h"
 #include "OysterManager.h"
+#include "MusicPlayer.h"
 #include <algorithm>
 #include <execution>
 #include <sstream>
@@ -363,6 +364,7 @@ namespace FishGame
 
     void BonusStageState::onActivate()
     {
+        getGame().getMusicPlayer().play(MusicID::BonusStage, true);
         // Initial spawn based on stage type
         switch (m_stageType)
         {

--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -1,6 +1,7 @@
 #include "MenuState.h"
 #include "Game.h"
 #include "StageIntroState.h"
+#include "MusicPlayer.h"
 #include <cmath>
 #include <algorithm>
 #include <numeric>
@@ -329,6 +330,7 @@ namespace FishGame
     void MenuState::onActivate()
     {
         // Reset state when menu becomes active
+        getGame().getMusicPlayer().play(MusicID::MenuTheme, true);
         m_isTransitioning = false;
         m_transitionAlpha = 255.0f;
         m_animationTime = 0.0f;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -6,6 +6,7 @@
 #include "GameOverState.h"
 #include "StageIntroState.h"
 #include "StageSummaryState.h"
+#include "MusicPlayer.h"
 #include <algorithm>
 #include <execution>
 #include <sstream>
@@ -915,6 +916,7 @@ namespace FishGame
 
     void PlayState::triggerWinSequence()
     {
+        getGame().getMusicPlayer().play(MusicID::StageCleared, false);
         m_gameState.gameWon = true;
         m_gameState.enemiesFleeing = true;
         m_gameState.winTimer = sf::Time::Zero;
@@ -951,6 +953,7 @@ namespace FishGame
             return;
 
         m_gameState.playerLives--;
+        getGame().getMusicPlayer().play(MusicID::PlayerDies, false);
         m_player->die();
 
         if (m_gameState.playerLives <= 0)
@@ -1316,6 +1319,7 @@ void PlayState::centerText(sf::Text& text)
             m_initialized = true;
             StageIntroState::configure(m_gameState.currentLevel, false);
             deferAction([this]() { requestStackPush(StateID::StageIntro); });
+            getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
         }
         else if (!m_initialized)
         {
@@ -1328,6 +1332,7 @@ void PlayState::centerText(sf::Text& text)
             m_savedLevel = 1;
             m_initialized = true;
             updateBackground(m_gameState.currentLevel);
+            getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
         }
 
         // Ensure camera starts centered on the player
@@ -1338,6 +1343,17 @@ void PlayState::centerText(sf::Text& text)
     {
         // Show mouse cursor again when leaving play state
         getGame().getWindow().setMouseCursorVisible(true);
+    }
+
+    static MusicID musicForLevel(int level)
+    {
+        int index = ((level - 1) / 3) % 3;
+        switch (index)
+        {
+        case 0: return MusicID::InGame1;
+        case 1: return MusicID::InGame2;
+        default: return MusicID::InGame3;
+        }
     }
 
     void PlayState::updateBackground(int level)

--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -1,5 +1,6 @@
 #include "StageIntroState.h"
 #include "Game.h"
+#include "MusicPlayer.h"
 #include <string>
 
 namespace {
@@ -60,6 +61,7 @@ void StageIntroState::configure(int level, bool pushNext, StateID nextState) {
 }
 
 void StageIntroState::onActivate() {
+  getGame().getMusicPlayer().play(MusicID::InstructionsHelp, false);
   auto &manager = getGame().getSpriteManager();
   auto &window = getGame().getWindow();
   auto &font = getGame().getFonts().get(Fonts::Main);

--- a/src/States/StageSummaryState.cpp
+++ b/src/States/StageSummaryState.cpp
@@ -1,5 +1,6 @@
 #include "StageSummaryState.h"
 #include "Game.h"
+#include "MusicPlayer.h"
 #include "StageIntroState.h"
 
 namespace {
@@ -49,6 +50,7 @@ void StageSummaryState::configure(int nextLevel, int levelScore,
 }
 
 void StageSummaryState::onActivate() {
+    getGame().getMusicPlayer().play(MusicID::ScoreSummary, false);
     auto& manager = getGame().getSpriteManager();
     auto& window = getGame().getWindow();
     m_overlaySprite.setTexture(manager.getTexture(TextureID::StageIntro));


### PR DESCRIPTION
## Summary
- add MusicPlayer class and sound resources
- link SFML audio library via CMake
- play MenuTheme, InstructionsHelp, BonusStage music when states activate
- change InGame music every 3 levels
- play PlayerDies and StageCleared cues
- play ScoreSummary on stage summary screen

## Testing
- `cmake -S . -B build` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685d994a30f08333978a134ed453ef2c