### PR TITLE
Fix missing musicForLevel forward declaration

### DIFF
--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -15,6 +15,9 @@
 
 namespace FishGame
 {
+    // Select appropriate background music for the given level
+    static MusicID musicForLevel(int level);
+
     PlayState::PlayState(Game& game)
         : State(game)
         , m_player(std::make_unique<Player>())


### PR DESCRIPTION
## Summary
- forward declare `musicForLevel` in `PlayState.cpp`

## Testing
- `cmake -B build -S .` *(fails: Could not find SFMLConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685d9bcdde988333bc8bcab06467b761