### PR TITLE
Speed up MusicPlayer with unordered_map

### DIFF
--- a/include/Core/MusicPlayer.h
+++ b/include/Core/MusicPlayer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <SFML/Audio.hpp>
-#include <map>
+#include <unordered_map>
 #include <string>
 
 namespace FishGame {
@@ -28,7 +28,7 @@ public:
 
 private:
     sf::Music m_music;
-    std::map<MusicID, std::string> m_filenames;
+    std::unordered_map<MusicID, std::string> m_filenames;
     float m_volume;
 };
 


### PR DESCRIPTION
## Summary
- speed up MusicPlayer lookups by replacing `std::map` with `std::unordered_map`

## Testing
- `cmake ..`
- `cmake --build . -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685d9d88349c833381d01d1e132a7e73