### PR TITLE
Improve music player playback

### DIFF
--- a/include/Core/MusicPlayer.h
+++ b/include/Core/MusicPlayer.h
@@ -3,6 +3,7 @@
 #include <SFML/Audio.hpp>
 #include <unordered_map>
 #include <string>
+#include <thread>
 
 namespace FishGame {
 
@@ -26,6 +27,8 @@ public:
     void stop();
     void setVolume(float volume);
 
+    static constexpr float FadeDuration = 0.5f; ///< seconds
+
 private:
     using MusicPtr = std::unique_ptr<sf::Music>;
 
@@ -37,6 +40,9 @@ private:
 
     /// Currently playing music (non-owning pointer)
     sf::Music* m_current;
+
+    /// Background cross fade thread
+    std::jthread m_fadeThread;
 
     float m_volume;
 };

--- a/src/Core/MusicPlayer.cpp
+++ b/src/Core/MusicPlayer.cpp
@@ -1,5 +1,6 @@
 #include "MusicPlayer.h"
 #include "GameExceptions.h"
+#include <chrono>
 
 namespace FishGame {
 
@@ -18,6 +19,9 @@ MusicPlayer::MusicPlayer()
     , m_current(nullptr)
     , m_volume(100.f)
 {
+    // Reserve to avoid rehashing during preload
+    m_musicTracks.reserve(m_filenames.size());
+
     // Pre-load music files for smoother playback
     for (const auto& [id, file] : m_filenames)
     {
@@ -39,20 +43,70 @@ void MusicPlayer::play(MusicID theme, bool loop)
         throw ResourceLoadException("Music ID not found");
     }
 
-    // Stop previous track if playing
-    if (m_current)
+    auto next = it->second.get();
+
+    // If same track requested, just ensure it is playing
+    if (m_current == next)
     {
-        m_current->stop();
+        next->setLoop(loop);
+        if (next->getStatus() != sf::SoundSource::Playing)
+        {
+            next->setVolume(m_volume);
+            next->play();
+        }
+        return;
     }
 
-    m_current = it->second.get();
+    // Cancel any existing fade thread
+    m_fadeThread.request_stop();
+    if (m_fadeThread.joinable())
+    {
+        m_fadeThread.join();
+    }
+
+    sf::Music* previous = m_current;
+    m_current = next;
+
+    // Start new track with volume 0 and fade in/out asynchronously
     m_current->setLoop(loop);
-    m_current->setVolume(m_volume);
+    m_current->setVolume(0.f);
     m_current->play();
+
+    const float targetVolume = m_volume;
+    m_fadeThread = std::jthread([this, previous, targetVolume](std::stop_token st)
+    {
+        const int steps = 20;
+        const auto delay = std::chrono::milliseconds(
+            static_cast<int>(FadeDuration * 1000 / steps));
+
+        for (int i = 0; i < steps && !st.stop_requested(); ++i)
+        {
+            float t = static_cast<float>(i + 1) / static_cast<float>(steps);
+
+            if (previous)
+            {
+                previous->setVolume(targetVolume * (1.f - t));
+            }
+            m_current->setVolume(targetVolume * t);
+            std::this_thread::sleep_for(delay);
+        }
+
+        if (previous && !st.stop_requested())
+        {
+            previous->stop();
+            previous->setVolume(targetVolume);
+        }
+    });
 }
 
 void MusicPlayer::stop()
 {
+    m_fadeThread.request_stop();
+    if (m_fadeThread.joinable())
+    {
+        m_fadeThread.join();
+    }
+
     if (m_current)
     {
         m_current->stop();


### PR DESCRIPTION
## Summary
- reserve music track storage
- support cross-fading between music tracks for smoother transitions

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: Interrupted after many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685da01fe1088333b395f282775b4143