### PR TITLE
Fix music handling in PlayState

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -236,6 +236,10 @@ namespace FishGame
 
         bool m_initialized;
 
+        // Track resuming of background music after death
+        bool m_musicResumePending{false};
+        sf::Time m_musicResumeTimer{sf::Time::Zero};
+
         // Constants
         static constexpr float m_hazardSpawnInterval = 8.0f;
         static constexpr float m_extendedPowerUpInterval = 15.0f;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -287,6 +287,16 @@ namespace FishGame
     {
         m_gameState.levelTime += deltaTime;
 
+        if (m_musicResumePending)
+        {
+            m_musicResumeTimer -= deltaTime;
+            if (m_musicResumeTimer <= sf::Time::Zero)
+            {
+                m_musicResumePending = false;
+                getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
+            }
+        }
+
         // Update environment system
         m_environmentSystem->update(deltaTime);
 
@@ -957,6 +967,9 @@ namespace FishGame
 
         m_gameState.playerLives--;
         getGame().getMusicPlayer().play(MusicID::PlayerDies, false);
+        m_musicResumePending = m_gameState.playerLives > 0;
+        if (m_musicResumePending)
+            m_musicResumeTimer = sf::seconds(1.5f);
         m_player->die();
 
         if (m_gameState.playerLives <= 0)


### PR DESCRIPTION
## Summary
- resume level music after death

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_685da99555688333bf090eed6e7a0309