### PR TITLE
Fix music resume after stage intro

### DIFF
--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -1350,6 +1350,11 @@ void PlayState::centerText(sf::Text& text)
             updateBackground(m_gameState.currentLevel);
             getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
         }
+        else
+        {
+            // Resume in-game music after pause or stage intro
+            getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
+        }
 
         // Ensure camera starts centered on the player
         updateCamera();


### PR DESCRIPTION
## Summary
- resume background music whenever PlayState becomes active

## Testing
- `cmake -S . -B build` *(fails: missing SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685dabfc18988333b6d80590ab05675c