### PR TITLE
Fix bonus stage not triggering after level 3

### DIFF
--- a/include/States/StageSummaryState.h
+++ b/include/States/StageSummaryState.h
@@ -16,6 +16,7 @@ template<> struct is_state<StageSummaryState> : std::true_type {};
 struct StageSummaryConfig {
     int nextLevel = 1;
     int levelScore = 0;
+    bool pushBonusStage = false;
     std::unordered_map<TextureID, int> counts;
     static StageSummaryConfig& getInstance() {
         static StageSummaryConfig instance;
@@ -29,7 +30,8 @@ public:
     ~StageSummaryState() override = default;
 
     static void configure(int nextLevel, int levelScore,
-                          const std::unordered_map<TextureID, int>& counts);
+                          const std::unordered_map<TextureID, int>& counts,
+                          bool pushBonusStage);
 
     void handleEvent(const sf::Event& event) override;
     bool update(sf::Time deltaTime) override;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -987,8 +987,9 @@ namespace FishGame
     {
         int levelScore = m_scoreSystem->getCurrentScore();
         const auto& fishCounts = m_scoreSystem->getFishCounts();
+        bool triggerBonus = (m_gameState.currentLevel % 3 == 0);
         StageSummaryState::configure(m_gameState.currentLevel + 1,
-                                     levelScore, fishCounts);
+                                     levelScore, fishCounts, triggerBonus);
         m_levelCounts.clear();
 
         m_gameState.currentLevel++;

--- a/src/States/StageSummaryState.cpp
+++ b/src/States/StageSummaryState.cpp
@@ -42,10 +42,12 @@ StageSummaryState::StageSummaryState(Game& game)
     : State(game), m_overlaySprite(), m_scoreText(), m_nextButtonSprite(), m_nextText(), m_items() {}
 
 void StageSummaryState::configure(int nextLevel, int levelScore,
-                                  const std::unordered_map<TextureID, int>& counts) {
+                                  const std::unordered_map<TextureID, int>& counts,
+                                  bool pushBonusStage) {
     auto& cfg = StageSummaryConfig::getInstance();
     cfg.nextLevel = nextLevel;
     cfg.levelScore = levelScore;
+    cfg.pushBonusStage = pushBonusStage;
     cfg.counts = counts;
 }
 
@@ -148,7 +150,13 @@ bool StageSummaryState::update(sf::Time) {
 void StageSummaryState::exitState() {
     deferAction([this]() {
         requestStackPop();
-        StageIntroState::configure(StageSummaryConfig::getInstance().nextLevel, false);
+        auto &cfg = StageSummaryConfig::getInstance();
+        if (cfg.pushBonusStage) {
+            StageIntroState::configure(0, true, StateID::BonusStage);
+        } else {
+            StageIntroState::configure(cfg.nextLevel, false);
+        }
+        cfg.pushBonusStage = false;
         requestStackPush(StateID::StageIntro);
     });
 }


### PR DESCRIPTION
## Summary
- add `pushBonusStage` flag to `StageSummaryConfig`
- push bonus stage intro from `StageSummaryState` when flag is set
- detect qualifying levels (every 3rd) in `PlayState::advanceLevel`

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685dafdaed3c833391ac489f1c7896eb