### PR TITLE
Fix bonus stage transitions

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -141,6 +141,7 @@ namespace FishGame
     {
         if (m_stageComplete)
         {
+            processDeferredActions();
             return false;
         }
 
@@ -364,6 +365,8 @@ namespace FishGame
 
     void BonusStageState::onActivate()
     {
+        // Pause any in-game music and start the bonus stage track
+        getGame().getMusicPlayer().stop();
         getGame().getMusicPlayer().play(MusicID::BonusStage, true);
         // Initial spawn based on stage type
         switch (m_stageType)


### PR DESCRIPTION
## Summary
- stop any playing music when entering the bonus stage and start bonus track
- process deferred actions when the bonus stage ends so it correctly advances to the next level

## Testing
- `cmake -B build -S .`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685db27fb19483339fafb2ce527dd032