### PR TITLE
Fix bonus stage music overlap

### DIFF
--- a/src/Core/MusicPlayer.cpp
+++ b/src/Core/MusicPlayer.cpp
@@ -107,10 +107,20 @@ void MusicPlayer::stop()
         m_fadeThread.join();
     }
 
+
+    // Stop any music that might still be playing
     if (m_current)
     {
         m_current->stop();
         m_current = nullptr;
+    }
+
+    for (auto& [_, music] : m_musicTracks)
+    {
+        if (music->getStatus() != sf::SoundSource::Stopped)
+        {
+            music->stop();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- stop any playing tracks when switching music to avoid overlap

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685db5b6b3208333ad2ccfaab280bc84