### PR TITLE
Show StageIntro after bonus stage completion

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -10,6 +10,7 @@
 #include "FishCollisionHandler.h"
 #include "OysterManager.h"
 #include "MusicPlayer.h"
+#include "StageIntroState.h"
 #include <algorithm>
 #include <execution>
 #include <sstream>
@@ -643,9 +644,11 @@ void BonusStageState::spawnBomb()
             }
         }
 
-        // Return to play state after delay
+        // Show intro for the next level when returning to PlayState
         deferAction([this]() {
             requestStackPop();
+            StageIntroState::configure(m_playerLevel + 1, false);
+            requestStackPush(StateID::StageIntro);
             });
     }
 

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -1334,8 +1334,6 @@ void PlayState::centerText(sf::Text& text)
 
             m_hud.messageText.setString("");
             m_initialized = true;
-            StageIntroState::configure(m_gameState.currentLevel, false);
-            deferAction([this]() { requestStackPush(StateID::StageIntro); });
             getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
         }
         else if (!m_initialized)


### PR DESCRIPTION
## Summary
- present the next level intro when leaving a bonus stage
- let PlayState no longer push StageIntro when returning from bonus stage

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685dba1148148333819461a2d364a715