### PR TITLE
Increase medium fish spawn rate

### DIFF
--- a/src/Managers/FishSpawner.cpp
+++ b/src/Managers/FishSpawner.cpp
@@ -20,22 +20,24 @@ namespace FishGame
         , m_spriteManager(&spriteManager)
     {
         // Initialize spawn configurations for each level
-        // Significantly reduced small fish spawn rates
+        // Emphasize medium fish by reducing small fish spawn rates
 
         // Level 1: Easier difficulty
-        m_smallFishConfig[1] = { 0.08f, 100.0f, m_windowSize.y - 100.0f};   // Further reduced spawn rate for level 1
-        // Increased spawn rate for more medium fish
-        m_mediumFishConfig[1] = { 0.8f, 150.0f, m_windowSize.y - 150.0f};
+        // Fewer small fish and more medium fish
+        m_smallFishConfig[1] = { 0.04f, 100.0f, m_windowSize.y - 100.0f};
+        m_mediumFishConfig[1] = { 1.2f, 150.0f, m_windowSize.y - 150.0f};
         m_largeFishConfig[1] = { 0.3f, 200.0f, m_windowSize.y - 200.0f};    // Reduced from 0.8f
 
         // Level 2: Medium difficulty
-        m_smallFishConfig[2] = { 0.2f, 100.0f, m_windowSize.y - 100.0f};    // Reduced from 0.5f (1 every 5 seconds)
-        m_mediumFishConfig[2] = { 0.9f, 150.0f, m_windowSize.y - 150.0f};
+        // Reduce small fish frequency and boost medium fish
+        m_smallFishConfig[2] = { 0.1f, 100.0f, m_windowSize.y - 100.0f};
+        m_mediumFishConfig[2] = { 1.4f, 150.0f, m_windowSize.y - 150.0f};
         m_largeFishConfig[2] = { 0.3f, 200.0f, m_windowSize.y - 200.0f};    // Reduced from 0.5f
 
         // Level 3: Hard difficulty
-        m_smallFishConfig[3] = { 0.3f, 100.0f, m_windowSize.y - 100.0f};    // Significantly reduced from 1.5f (1 every ~3.3 seconds)
-        m_mediumFishConfig[3] = { 1.0f, 150.0f, m_windowSize.y - 150.0f};
+        // Keep small fish scarce and further increase medium fish
+        m_smallFishConfig[3] = { 0.15f, 100.0f, m_windowSize.y - 100.0f};
+        m_mediumFishConfig[3] = { 1.6f, 150.0f, m_windowSize.y - 150.0f};
         m_largeFishConfig[3] = { 0.4f, 200.0f, m_windowSize.y - 200.0f};    // Reduced from 0.7f
 
         // Setup spawners


### PR DESCRIPTION
## Summary
- tweak FishSpawner small/medium fish spawn rates to generate fewer small fish and more medium fish

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*
- `cmake --build build` *(fails: no build files)*

------
https://chatgpt.com/codex/tasks/task_e_685dbc6850948333a79601acb41441a8