### PR TITLE
Stop bonus music after stage

### DIFF
--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -36,6 +36,7 @@ namespace FishGame
         bool update(sf::Time deltaTime) override;
         void render() override;
         void onActivate() override;
+        void onDeactivate() override;
 
     private:
         struct BonusObjective

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -412,6 +412,12 @@ namespace FishGame
         updateCamera();
     }
 
+    void BonusStageState::onDeactivate()
+    {
+        // Stop the bonus stage music when leaving the state
+        getGame().getMusicPlayer().stop();
+    }
+
     void BonusStageState::updateTreasureHunt(sf::Time deltaTime)
     {
         // Spawn more oysters periodically


### PR DESCRIPTION
## Summary
- allow BonusStageState to stop bonus music on exit

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_685e6c0418c483338f19361c59744ed4