### PR TITLE
Add delayed respawn for player fish

### DIFF
--- a/include/Core/GameConstants.h
+++ b/include/Core/GameConstants.h
@@ -95,6 +95,7 @@ namespace FishGame
         const sf::Time FPS_UPDATE_INTERVAL = sf::seconds(1.0f);
         const sf::Time SCHOOL_EXTRACT_INTERVAL = sf::seconds(0.1f);
         const sf::Time WIN_SEQUENCE_DURATION = sf::seconds(5.0f);
+        const sf::Time RESPAWN_DELAY = sf::seconds(2.0f);
 
         // ==================== Particle Effects ====================
         constexpr int DEFAULT_PARTICLE_COUNT = 8;

--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -240,6 +240,9 @@ namespace FishGame
         bool m_musicResumePending{false};
         sf::Time m_musicResumeTimer{sf::Time::Zero};
 
+        bool m_respawnPending{false};
+        sf::Time m_respawnTimer{sf::Time::Zero};
+
         // Constants
         static constexpr float m_hazardSpawnInterval = 8.0f;
         static constexpr float m_extendedPowerUpInterval = 15.0f;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -297,6 +297,17 @@ namespace FishGame
             }
         }
 
+        if (m_respawnPending)
+        {
+            m_respawnTimer -= deltaTime;
+            if (m_respawnTimer <= sf::Time::Zero)
+            {
+                m_respawnPending = false;
+                m_player->respawn();
+                createParticleEffect(m_player->getPosition(), Constants::RESPAWN_PARTICLE_COLOR);
+            }
+        }
+
         // Update environment system
         m_environmentSystem->update(deltaTime);
 
@@ -978,8 +989,8 @@ namespace FishGame
         }
         else
         {
-            m_player->respawn();
-            createParticleEffect(m_player->getPosition(), Constants::RESPAWN_PARTICLE_COLOR);
+            m_respawnPending = true;
+            m_respawnTimer = Constants::RESPAWN_DELAY;
         }
     }
 


### PR DESCRIPTION
## Summary
- add `RESPAWN_DELAY` constant
- keep PlayState respawn timers and delay respawn when player dies

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_685f166087a0833389b71ea56a793d2a