### PR TITLE
Adjust NEXT button color

### DIFF
--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -84,6 +84,7 @@ void StageIntroState::onActivate() {
   m_nextButtonSprite.setOrigin(b.width / 2.f, b.height / 2.f);
   m_nextButtonSprite.setScale(Constants::MENU_BUTTON_SCALE, Constants::MENU_BUTTON_SCALE);
   m_nextButtonSprite.setPosition(window.getSize().x / 2.f, window.getSize().y - 110.f);
+  m_nextButtonSprite.setColor(sf::Color(128, 128, 128));
 
   m_nextText.setFont(font);
   m_nextText.setString("NEXT");
@@ -91,6 +92,7 @@ void StageIntroState::onActivate() {
   auto nb = m_nextText.getLocalBounds();
   m_nextText.setOrigin(nb.width / 2.f, nb.height / 2.f);
   m_nextText.setPosition(m_nextButtonSprite.getPosition());
+  m_nextText.setFillColor(sf::Color(128, 128, 128));
   m_buttonHovered = false;
   m_elapsed = sf::Time::Zero;
 }

--- a/src/States/StageSummaryState.cpp
+++ b/src/States/StageSummaryState.cpp
@@ -74,6 +74,7 @@ void StageSummaryState::onActivate() {
     m_nextButtonSprite.setOrigin(b.width/2.f, b.height/2.f);
     m_nextButtonSprite.setScale(Constants::MENU_BUTTON_SCALE, Constants::MENU_BUTTON_SCALE);
     m_nextButtonSprite.setPosition(window.getSize().x/2.f, window.getSize().y - 120.f);
+    m_nextButtonSprite.setColor(sf::Color(128, 128, 128));
 
     m_nextText.setFont(font);
     m_nextText.setString("NEXT");
@@ -81,6 +82,7 @@ void StageSummaryState::onActivate() {
     auto nb = m_nextText.getLocalBounds();
     m_nextText.setOrigin(nb.width/2.f, nb.height/2.f + 10.0f);
     m_nextText.setPosition(m_nextButtonSprite.getPosition());
+    m_nextText.setFillColor(sf::Color(128, 128, 128));
     m_buttonHovered = false;
 
     setupItems();


### PR DESCRIPTION
## Summary
- make NEXT button grey in stage intro
- make NEXT button grey in stage summary

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_685f1709affc8333a63cba16bb8d8f90