### PR TITLE
Improve time power-ups in bonus stage

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -172,9 +172,9 @@ namespace FishGame
             break;
         }
 
-        // Spawn time extension power-up periodically
+        // Spawn time extension power-ups periodically
         m_timePowerUpTimer += deltaTime;
-        if (m_timePowerUpTimer.asSeconds() > 8.0f && m_bonusItems.size() < 10)
+        if (m_timePowerUpTimer.asSeconds() > 5.0f && m_bonusItems.size() < 15)
         {
             m_timePowerUpTimer = sf::Time::Zero;
             spawnTimePowerUp();
@@ -385,6 +385,9 @@ namespace FishGame
             break;
         }
 
+        // Spawn a few initial time power-ups
+        spawnTimePowerUp();
+
         // Update initial objective text
         std::ostringstream objStream;
         objStream << m_objective.description << " (" << m_objective.currentCount
@@ -593,13 +596,17 @@ namespace FishGame
 
 void BonusStageState::spawnTimePowerUp()
 {
-    auto power = std::make_unique<AddTimePowerUp>();
-    float x = m_xDist(m_randomEngine);
-    float y = m_yDist(m_randomEngine);
-    power->setPosition(x, y);
-    power->m_baseY = y;
-    power->initializeSprite(getGame().getSpriteManager());
-    m_bonusItems.push_back(std::move(power));
+    // Spawn a couple of time extensions at once to make the stage a bit easier
+    for (int i = 0; i < 2 && m_bonusItems.size() < 30; ++i)
+    {
+        auto power = std::make_unique<AddTimePowerUp>();
+        float x = m_xDist(m_randomEngine);
+        float y = m_yDist(m_randomEngine);
+        power->setPosition(x, y);
+        power->m_baseY = y;
+        power->initializeSprite(getGame().getSpriteManager());
+        m_bonusItems.push_back(std::move(power));
+    }
 }
 
 void BonusStageState::spawnStarfish()


### PR DESCRIPTION
## Summary
- spawn an initial batch of AddTimePowerUps in `BonusStageState`
- make AddTimePowerUps spawn more often and increase overall limit
- create multiple AddTimePowerUps each time `spawnTimePowerUp()` is called

## Testing
- `cmake -S . -B build` *(fails: Could not find package SFML)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_685f1735c2248333b5d205010bd02e13