### PR TITLE
Add sound effects

### DIFF
--- a/include/Core/Game.h
+++ b/include/Core/Game.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include "ResourceHolder.h"
 #include "MusicPlayer.h"
+#include "SoundPlayer.h"
 #include "State.h"
 #include "Player.h"
 #include "GameConstants.h"
@@ -35,6 +36,8 @@ namespace FishGame
         SpriteManager& getSpriteManager() { return *m_spriteManager; }
         MusicPlayer& getMusicPlayer() { return *m_musicPlayer; }
         const MusicPlayer& getMusicPlayer() const { return *m_musicPlayer; }
+        SoundPlayer& getSoundPlayer() { return *m_soundPlayer; }
+        const SoundPlayer& getSoundPlayer() const { return *m_soundPlayer; }
 
         // State management
         void pushState(StateID id);
@@ -105,6 +108,7 @@ namespace FishGame
 
         std::unique_ptr<SpriteManager> m_spriteManager;
         std::unique_ptr<MusicPlayer> m_musicPlayer;
+        std::unique_ptr<SoundPlayer> m_soundPlayer;
 
         // Performance tracking
         struct PerformanceMetrics

--- a/include/Core/SoundPlayer.h
+++ b/include/Core/SoundPlayer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <SFML/Audio.hpp>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <string>
+
+namespace FishGame {
+
+enum class SoundEffectID {
+    Bite1,
+    Bite2,
+    Bite3,
+    Bite4,
+    FreezePowerup,
+    LifePowerup,
+    MineExplode,
+    MouseDown,
+    MouseOver,
+    OysterPearl,
+    PlayerGrow,
+    PlayerPoison,
+    PlayerSpawn,
+    PlayerStunned,
+    PufferBounce,
+    SpeedEnd,
+    SpeedStart,
+    StageIntro,
+    StarPickup
+};
+
+class SoundPlayer {
+public:
+    SoundPlayer();
+
+    void play(SoundEffectID effect);
+    void setVolume(float volume);
+
+private:
+    using BufferPtr = std::unique_ptr<sf::SoundBuffer>;
+
+    std::unordered_map<SoundEffectID, BufferPtr> m_soundBuffers;
+    std::unordered_map<SoundEffectID, std::string> m_filenames;
+    std::vector<sf::Sound> m_sounds;
+    float m_volume;
+};
+
+}
+

--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -10,6 +10,7 @@
 #include "FrenzySystem.h"
 #include "PowerUp.h"
 #include "ScoreSystem.h"
+#include "SoundPlayer.h"
 
 namespace FishGame
 {
@@ -69,6 +70,8 @@ namespace FishGame
         void applyPoisonEffect(sf::Time duration);
         void setControlsReversed(bool reversed) { m_controlsReversed = reversed; }
 
+        void setSoundPlayer(SoundPlayer* player) { m_soundPlayer = player; }
+
         // Size information
         bool isAtMaxSize() const { return m_currentStage >= Constants::MAX_STAGES; }
         void setWindowBounds(const sf::Vector2u& windowSize);
@@ -112,6 +115,7 @@ namespace FishGame
         PowerUpManager* m_powerUpManager;
         ScoreSystem* m_scoreSystem;
         SpriteManager* m_spriteManager;
+        SoundPlayer* m_soundPlayer{ nullptr };
 
         // Invulnerability and damage
         sf::Time m_invulnerabilityTimer;

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -9,6 +9,7 @@
 #include "StageIntroState.h"
 #include "StageSummaryState.h"
 #include "MusicPlayer.h"
+#include "SoundPlayer.h"
 #include <algorithm>
 #include "GameExceptions.h"
 
@@ -28,6 +29,7 @@ namespace FishGame
         , m_stateFactories()
         , m_spriteManager(nullptr)
         , m_musicPlayer(std::make_unique<MusicPlayer>())
+        , m_soundPlayer(std::make_unique<SoundPlayer>())
         , m_metrics()
     {
         m_window.setFramerateLimit(m_frameRateLimit);

--- a/src/Core/SoundPlayer.cpp
+++ b/src/Core/SoundPlayer.cpp
@@ -1,0 +1,76 @@
+#include "SoundPlayer.h"
+#include "GameExceptions.h"
+
+namespace FishGame {
+
+SoundPlayer::SoundPlayer()
+    : m_soundBuffers()
+    , m_filenames{
+        {SoundEffectID::Bite1, "Bite1.wav"},
+        {SoundEffectID::Bite2, "Bite2.wav"},
+        {SoundEffectID::Bite3, "Bite3.wav"},
+        {SoundEffectID::Bite4, "Bite4.wav"},
+        {SoundEffectID::FreezePowerup, "FreezePowerup.wav"},
+        {SoundEffectID::LifePowerup, "LifePowerup.wav"},
+        {SoundEffectID::MineExplode, "MineExplode.wav"},
+        {SoundEffectID::MouseDown, "MouseDown.wav"},
+        {SoundEffectID::MouseOver, "MouseOver.wav"},
+        {SoundEffectID::OysterPearl, "OysterPearl.wav"},
+        {SoundEffectID::PlayerGrow, "PlayerGrow.wav"},
+        {SoundEffectID::PlayerPoison, "PlayerPoison.wav"},
+        {SoundEffectID::PlayerSpawn, "PlayerSpawn.wav"},
+        {SoundEffectID::PlayerStunned, "PlayerStunned.wav"},
+        {SoundEffectID::PufferBounce, "PufferBounce.wav"},
+        {SoundEffectID::SpeedEnd, "SpeedEnd.wav"},
+        {SoundEffectID::SpeedStart, "SpeedStart.wav"},
+        {SoundEffectID::StageIntro, "StageIntro.wav"},
+        {SoundEffectID::StarPickup, "StarPickup.wav"}}
+    , m_sounds(16)
+    , m_volume(100.f)
+{
+    m_soundBuffers.reserve(m_filenames.size());
+    for (const auto& [id, file] : m_filenames) {
+        auto buffer = std::make_unique<sf::SoundBuffer>();
+        if (!buffer->loadFromFile(file)) {
+            throw ResourceLoadException("Failed to load sound: " + file);
+        }
+        m_soundBuffers.emplace(id, std::move(buffer));
+    }
+
+    for (auto& sound : m_sounds) {
+        sound.setVolume(m_volume);
+    }
+}
+
+void SoundPlayer::play(SoundEffectID effect)
+{
+    auto it = m_soundBuffers.find(effect);
+    if (it == m_soundBuffers.end())
+        return;
+
+    for (auto& sound : m_sounds) {
+        if (sound.getStatus() != sf::Sound::Playing) {
+            sound.setBuffer(*it->second);
+            sound.setVolume(m_volume);
+            sound.play();
+            return;
+        }
+    }
+
+    // If all sounds are playing, restart the first one
+    m_sounds.front().stop();
+    m_sounds.front().setBuffer(*it->second);
+    m_sounds.front().setVolume(m_volume);
+    m_sounds.front().play();
+}
+
+void SoundPlayer::setVolume(float volume)
+{
+    m_volume = volume;
+    for (auto& sound : m_sounds) {
+        sound.setVolume(m_volume);
+    }
+}
+
+} // namespace FishGame
+

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -4,6 +4,7 @@
 #include "PowerUp.h"
 #include "SpecialFish.h"
 #include "Animator.h"
+#include "SoundPlayer.h"
 #include "CollisionDetector.h"
 #include "GenericFish.h"
 #include <SFML/Window.hpp>
@@ -33,6 +34,7 @@ namespace FishGame
         , m_powerUpManager(nullptr)
         , m_scoreSystem(nullptr)
         , m_spriteManager(nullptr)
+        , m_soundPlayer(nullptr)
         , m_invulnerabilityTimer(sf::Time::Zero)
         , m_damageCooldown(sf::Time::Zero)
         , m_speedMultiplier(1.0f)
@@ -109,7 +111,11 @@ namespace FishGame
         if (m_damageCooldown > sf::Time::Zero)
             m_damageCooldown -= deltaTime;
         if (m_speedBoostTimer > sf::Time::Zero)
+        {
             m_speedBoostTimer -= deltaTime;
+            if (m_speedBoostTimer <= sf::Time::Zero && m_soundPlayer)
+                m_soundPlayer->play(SoundEffectID::SpeedEnd);
+        }
 
         // Handle input
         handleInput();
@@ -516,19 +522,25 @@ namespace FishGame
         m_invulnerabilityTimer = m_invulnerabilityDuration;
         m_controlsReversed = false;
         m_poisonColorTimer = sf::Time::Zero;
+        if (m_soundPlayer)
+            m_soundPlayer->play(SoundEffectID::PlayerSpawn);
     }
 
-    void Player::applySpeedBoost(float multiplier, sf::Time duration)
-    {
-        m_speedMultiplier = multiplier;
-        m_speedBoostTimer = duration;
-    }
+void Player::applySpeedBoost(float multiplier, sf::Time duration)
+{
+    m_speedMultiplier = multiplier;
+    m_speedBoostTimer = duration;
+    if (m_soundPlayer)
+        m_soundPlayer->play(SoundEffectID::SpeedStart);
+}
 
-    void Player::applyPoisonEffect(sf::Time duration)
-    {
-        m_poisonColorTimer = duration;
-        m_controlsReversed = true;
-    }
+void Player::applyPoisonEffect(sf::Time duration)
+{
+    m_poisonColorTimer = duration;
+    m_controlsReversed = true;
+    if (m_soundPlayer)
+        m_soundPlayer->play(SoundEffectID::PlayerPoison);
+}
 
     void Player::triggerEatEffect()
     {
@@ -593,8 +605,10 @@ namespace FishGame
         }
     }
 
-    void Player::updateStage()
-    {
+void Player::updateStage()
+{
+        if (m_soundPlayer)
+            m_soundPlayer->play(SoundEffectID::PlayerGrow);
         m_radius = static_cast<float>(m_baseRadius *
             std::pow(m_growthFactor, static_cast<float>(m_currentStage - 1)));
 

--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -195,8 +195,11 @@ namespace FishGame
 
         if (hoveredOption.has_value())
         {
-            m_hoveredOption = static_cast<MenuOption>(hoveredOption.value());
-            m_selectedOption = static_cast<MenuOption>(hoveredOption.value());
+            auto newOption = static_cast<MenuOption>(hoveredOption.value());
+            if (!m_hoveredOption.has_value() || newOption != *m_hoveredOption)
+                getGame().getSoundPlayer().play(SoundEffectID::MouseOver);
+            m_hoveredOption = newOption;
+            m_selectedOption = newOption;
         }
         else
         {
@@ -216,6 +219,7 @@ namespace FishGame
             [](const auto& item) { return item.sprite.getGlobalBounds(); });
         if (clickedOption.has_value())
         {
+            getGame().getSoundPlayer().play(SoundEffectID::MouseDown);
             m_selectedOption = static_cast<MenuOption>(clickedOption.value());
             selectOption();
         }

--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -62,6 +62,7 @@ void StageIntroState::configure(int level, bool pushNext, StateID nextState) {
 
 void StageIntroState::onActivate() {
   getGame().getMusicPlayer().play(MusicID::InstructionsHelp, false);
+  getGame().getSoundPlayer().play(SoundEffectID::StageIntro);
   auto &manager = getGame().getSpriteManager();
   auto &window = getGame().getWindow();
   auto &font = getGame().getFonts().get(Fonts::Main);


### PR DESCRIPTION
## Summary
- implement `SoundPlayer` to manage short sound effects
- integrate `SoundPlayer` with `Game`, `Player`, and states
- play effects on player actions and menu events

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68603e58a12c83338b9c7e65dec735e3