### PR TITLE
Add frenzy sound effects

### DIFF
--- a/include/Core/SoundPlayer.h
+++ b/include/Core/SoundPlayer.h
@@ -27,7 +27,9 @@ enum class SoundEffectID {
     SpeedEnd,
     SpeedStart,
     StageIntro,
-    StarPickup
+    StarPickup,
+    FeedingFrenzy,
+    SuperFrenzy
 };
 
 class SoundPlayer {

--- a/include/Systems/FrenzySystem.h
+++ b/include/Systems/FrenzySystem.h
@@ -2,6 +2,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <deque>
+#include "SoundPlayer.h"
 
 namespace FishGame
 {
@@ -37,6 +38,7 @@ namespace FishGame
 
         // Setters
         void setPosition(float x, float y);
+        void setSoundPlayer(SoundPlayer* player) { m_soundPlayer = player; }
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
@@ -70,6 +72,7 @@ namespace FishGame
         float m_textRotation;
         sf::Color m_currentColor;
         sf::Time m_animationTimer;
+        SoundPlayer* m_soundPlayer{ nullptr };
 
         // Timing constants
         static constexpr float m_frenzyActivationTime = 2.0f;     // 4 fish in 2 seconds

--- a/src/Core/SoundPlayer.cpp
+++ b/src/Core/SoundPlayer.cpp
@@ -24,7 +24,9 @@ SoundPlayer::SoundPlayer()
         {SoundEffectID::SpeedEnd, "SpeedEnd.wav"},
         {SoundEffectID::SpeedStart, "SpeedStart.wav"},
         {SoundEffectID::StageIntro, "StageIntro.wav"},
-        {SoundEffectID::StarPickup, "StarPickup.wav"}}
+        {SoundEffectID::StarPickup, "StarPickup.wav"},
+        {SoundEffectID::FeedingFrenzy, "FeedingFrenzy.wav"},
+        {SoundEffectID::SuperFrenzy, "SuperFrenzy.wav"}}
     , m_sounds(16)
     , m_volume(100.f)
 {

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -59,6 +59,8 @@ namespace FishGame
     {
         initializeSystems();
         m_player->setSoundPlayer(&getGame().getSoundPlayer());
+        if (m_frenzySystem)
+            m_frenzySystem->setSoundPlayer(&getGame().getSoundPlayer());
 
         // Reserve capacity for containers
         m_entities.reserve(Constants::MAX_ENTITIES);

--- a/src/Systems/FrenzySystem.cpp
+++ b/src/Systems/FrenzySystem.cpp
@@ -1,5 +1,6 @@
 #include "FrenzySystem.h"
 #include "GameConstants.h"
+#include "SoundPlayer.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
@@ -21,6 +22,7 @@ namespace FishGame
         , m_textRotation(0.0f)
         , m_currentColor(sf::Color::White)
         , m_animationTimer(sf::Time::Zero)
+        , m_soundPlayer(nullptr)
     {
         // Setup frenzy text
         m_frenzyText.setFont(font);
@@ -188,6 +190,8 @@ namespace FishGame
                 m_multiplierText.setString("2X Score Multiplier");
                 m_currentColor = sf::Color::Yellow;
                 m_textScale = 1.5f;
+                if (m_soundPlayer)
+                    m_soundPlayer->play(SoundEffectID::FeedingFrenzy);
                 break;
 
             case FrenzyLevel::SuperFrenzy:
@@ -195,6 +199,8 @@ namespace FishGame
                 m_multiplierText.setString("4X Score Multiplier");
                 m_currentColor = sf::Color::Magenta;
                 m_textScale = 2.0f;
+                if (m_soundPlayer)
+                    m_soundPlayer->play(SoundEffectID::SuperFrenzy);
                 break;
             }
 


### PR DESCRIPTION
## Summary
- extend `SoundEffectID` with FeedingFrenzy and SuperFrenzy
- load new sounds in `SoundPlayer`
- allow `FrenzySystem` to play sound effects
- hook up the sound player from `PlayState`

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6860471013e483339172fb0ef7850322