### PR TITLE
Freeze camera at player death

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -243,6 +243,10 @@ namespace FishGame
         bool m_respawnPending{false};
         sf::Time m_respawnTimer{sf::Time::Zero};
 
+        // Camera freeze when player dies
+        bool m_cameraFrozen{false};
+        sf::Vector2f m_cameraFreezePos;
+
         // Constants
         static constexpr float m_hazardSpawnInterval = 8.0f;
         static constexpr float m_extendedPowerUpInterval = 15.0f;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -307,6 +307,7 @@ namespace FishGame
             {
                 m_respawnPending = false;
                 m_player->respawn();
+                m_cameraFrozen = false;
                 createParticleEffect(m_player->getPosition(), Constants::RESPAWN_PARTICLE_COLOR);
             }
         }
@@ -1006,6 +1007,13 @@ namespace FishGame
         if (m_player->isInvulnerable())
             return;
 
+        // Freeze camera at death position
+        m_cameraFrozen = true;
+        m_cameraFreezePos = m_player->getPosition();
+        sf::Vector2f halfSize = m_view.getSize() * 0.5f;
+        m_cameraFreezePos.x = std::clamp(m_cameraFreezePos.x, halfSize.x, m_worldSize.x - halfSize.x);
+        m_cameraFreezePos.y = std::clamp(m_cameraFreezePos.y, halfSize.y, m_worldSize.y - halfSize.y);
+
         m_gameState.playerLives--;
         getGame().getMusicPlayer().play(MusicID::PlayerDies, false);
         m_musicResumePending = m_gameState.playerLives > 0;
@@ -1263,6 +1271,12 @@ namespace FishGame
     {
         if (!m_player)
             return;
+
+        if (m_cameraFrozen)
+        {
+            m_view.setCenter(m_cameraFreezePos);
+            return;
+        }
 
         sf::Vector2f target = m_player->getPosition();
         sf::Vector2f halfSize = m_view.getSize() * 0.5f;


### PR DESCRIPTION
## Summary
- keep track of the camera position when the player dies
- freeze the camera until respawn and then resume following the player

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_686048250da08333b682a4cc9c6d7a14