### PR TITLE
Tune school spawn chance for solo fish

### DIFF
--- a/include/Core/GameConstants.h
+++ b/include/Core/GameConstants.h
@@ -61,8 +61,10 @@ namespace FishGame
         constexpr float BARRACUDA_SPAWN_RATE = 0.05f;
         constexpr float PUFFERFISH_SPAWN_RATE = 0.1f;
         constexpr float ANGELFISH_SPAWN_RATE = 0.05f;
-        constexpr float SCHOOL_SPAWN_CHANCE = 0.05f;
-        constexpr float MAX_SCHOOL_SPAWN_CHANCE = 0.10f;
+        // Spawn chance for schools of small fish. Lower values mean schools
+        // appear less frequently and individual spawns are more common.
+        constexpr float SCHOOL_SPAWN_CHANCE = 0.02f;
+        constexpr float MAX_SCHOOL_SPAWN_CHANCE = 0.05f;
         constexpr float POISONFISH_SPAWN_RATE = 0.15f;
 
         // ==================== Visual Settings ====================

--- a/include/Managers/EnhancedFishSpawner.h
+++ b/include/Managers/EnhancedFishSpawner.h
@@ -19,7 +19,9 @@ namespace FishGame
         float pufferfishSpawnRate = 0.15f;
         float angelfishSpawnRate = 0.2f;
         float poisonFishSpawnRate = 0.12f;
-        float schoolSpawnChance = 0.3f;
+        // Chance to spawn a school of small fish. Keeping this low makes
+        // individual spawns more likely than schools by default.
+        float schoolSpawnChance = 0.02f;
     };
 
     class EnhancedFishSpawner : public FishSpawner


### PR DESCRIPTION
## Summary
- lower default chance of spawning schools so small fish appear alone more often
- document new spawn probabilities

## Testing
- `cmake -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68604a2b8a988333b307d9fbed81ac0b