### PR TITLE
Fix frenzy progression

### DIFF
--- a/src/Systems/FrenzySystem.cpp
+++ b/src/Systems/FrenzySystem.cpp
@@ -154,6 +154,8 @@ namespace FishGame
             {
                 setFrenzyLevel(FrenzyLevel::Frenzy);
                 m_frenzyTimer = sf::seconds(m_frenzyMaintainTime);
+                // Reset history so player must eat additional fish for Super Frenzy
+                m_eatHistory.clear();
             }
         }
         else if (m_currentLevel == FrenzyLevel::Frenzy && recentEats >= m_requiredFishCount)


### PR DESCRIPTION
## Summary
- prevent immediate upgrade to Super Frenzy by clearing history when Frenzy starts

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68604a8445b08333915a475633f73a0b