### PR TITLE
Fix bonus stage sound

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -117,6 +117,7 @@ namespace FishGame
         m_player->setWindowBounds(getGame().getWindow().getSize());
         m_player->setPosition(960.0f, 540.0f);
         m_player->initializeSprite(getGame().getSpriteManager());
+        m_player->setSoundPlayer(&getGame().getSoundPlayer());
 
         // Reserve containers
         m_entities.reserve(50);


### PR DESCRIPTION
## Summary
- enable sound effects in bonus stages by assigning `SoundPlayer` to the bonus stage player

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_686055257e5083339319a9ee5bf62e4f