### PR TITLE
Enable bomb sound for AI fish collisions

### DIFF
--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -249,7 +249,8 @@ namespace FishGame
                 }
             });
 
-        ::FishGame::FishCollisionHandler::processFishHazardCollisions(m_entities, m_hazards);
+        ::FishGame::FishCollisionHandler::processFishHazardCollisions(
+            m_entities, m_hazards, &getGame().getSoundPlayer());
 
         // Process bomb explosions affecting entities
         ::FishGame::processBombExplosions(m_entities, m_hazards);

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -680,7 +680,8 @@ namespace FishGame
             });
 
         // Fish vs hazards - using the global FishCollisionHandler from FishCollisionHandler.h
-        ::FishGame::FishCollisionHandler::processFishHazardCollisions(m_entities, m_hazards);
+        ::FishGame::FishCollisionHandler::processFishHazardCollisions(
+            m_entities, m_hazards, &getGame().getSoundPlayer());
 
         // Bomb explosions
         processBombExplosions(m_entities, m_hazards);


### PR DESCRIPTION
## Summary
- play `MineExplode` sound when any fish triggers a bomb
- pass the game's `SoundPlayer` to `processFishHazardCollisions`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6860550cd2bc83339c834c1da3bc89c4