### PR TITLE
Fix pufferfish animation when puffed

### DIFF
--- a/src/Entities/Fish.cpp
+++ b/src/Entities/Fish.cpp
@@ -316,7 +316,13 @@ namespace FishGame
         if (m_animator && m_renderMode == RenderMode::Sprite)
         {
             bool newFacingRight = m_velocity.x > 0.f;
-            if (!m_eating && std::abs(m_velocity.x) > 1.f && newFacingRight != m_facingRight)
+            bool inflatedPuffer = false;
+            if (const auto* puffer = dynamic_cast<const Pufferfish*>(this))
+            {
+                inflatedPuffer = puffer->isInflated();
+            }
+
+            if (!m_eating && std::abs(m_velocity.x) > 1.f && newFacingRight != m_facingRight && !inflatedPuffer)
             {
                 m_facingRight = newFacingRight;
                 std::string turn = m_facingRight ? "turnLeftToRight" : "turnRightToLeft";
@@ -345,9 +351,12 @@ namespace FishGame
                 m_turnTimer += deltaTime;
                 if (m_turnTimer.asSeconds() >= m_turnDuration)
                 {
-                    std::string swim = m_facingRight ? "swimRight" : "swimLeft";
-                    m_animator->play(swim);
-                    m_currentAnimation = swim;
+                    if (!inflatedPuffer)
+                    {
+                        std::string swim = m_facingRight ? "swimRight" : "swimLeft";
+                        m_animator->play(swim);
+                        m_currentAnimation = swim;
+                    }
                     m_turning = false;
                 }
             }

--- a/src/Entities/SpecialFish.cpp
+++ b/src/Entities/SpecialFish.cpp
@@ -502,6 +502,8 @@ namespace FishGame
         m_isPuffing = true;
         m_puffTimer = sf::Time::Zero;
         m_puffPhase = PuffPhase::Inflating;
+        m_turning = false;
+        m_turnTimer = sf::Time::Zero;
 
         if (m_animator)
         {


### PR DESCRIPTION
## Summary
- stop turning animations when pufferfish is inflated
- keep inflated animation active during turns
- reset turn state when starting to inflate

## Testing
- `cmake ..` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6860631c009c8333ba39a1fa06905e9c