### PR TITLE
Improve fish wandering near screen edges

### DIFF
--- a/include/Systems/Strategy.h
+++ b/include/Systems/Strategy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Entity.h"
+#include "GameConstants.h"
 #include <random>
 #include <SFML/System/Time.hpp>
 

--- a/src/Systems/Strategy.cpp
+++ b/src/Systems/Strategy.cpp
@@ -40,16 +40,43 @@ namespace FishGame
     void RandomWanderStrategy::update(Entity& entity, sf::Time deltaTime)
     {
         m_changeTimer -= deltaTime;
+
+        float speed = 100.f;
+        sf::Vector2f pos = entity.getPosition();
+        sf::Vector2f velocity = entity.getVelocity();
+
+        if (auto* fish = dynamic_cast<Fish*>(&entity))
+        {
+            speed = fish->getSpeed();
+
+            const sf::Vector2u win = fish->getWindowBounds();
+            const float margin = 60.f;
+
+            if ((pos.x < margin && velocity.x < 0.f) ||
+                (pos.x > win.x - margin && velocity.x > 0.f))
+            {
+                velocity.x = -velocity.x;
+            }
+
+            if ((pos.y < margin && velocity.y < 0.f) ||
+                (pos.y > win.y - margin && velocity.y > 0.f))
+            {
+                velocity.y = -velocity.y;
+            }
+        }
+
         if (m_changeTimer <= sf::Time::Zero)
         {
-            std::uniform_real_distribution<float> angleDist(0.f, 2.f * 3.14159265f);
+            std::uniform_real_distribution<float> angleDist(0.f, 2.f * Constants::PI);
             float angle = angleDist(m_engine);
-            float speed = 100.f;
-            if (auto* fish = dynamic_cast<Fish*>(&entity))
-                speed = fish->getSpeed();
-            entity.setVelocity(std::cos(angle) * speed, std::sin(angle) * speed);
+
+            velocity.x = std::cos(angle) * speed;
+            velocity.y = std::sin(angle) * speed;
+
             m_changeTimer = sf::seconds(1.f);
         }
+
+        entity.setVelocity(velocity);
         entity.updatePosition(deltaTime);
     }
 }


### PR DESCRIPTION
## Summary
- include `GameConstants.h` in strategy header
- enhance `RandomWanderStrategy` with edge checks and velocity reversal
  to prevent fish from slowing down near the edges

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68606a550aec8333ad9438af1f78ddcd