### PR TITLE
Fix next level intro after bonus stage

### DIFF
--- a/include/States/BonusStageState.h
+++ b/include/States/BonusStageState.h
@@ -26,6 +26,18 @@ namespace FishGame
         SurvivalChallenge // Survive waves of predators
     };
 
+    struct BonusStageConfig
+    {
+        BonusStageType type = BonusStageType::FeedingFrenzy;
+        int playerLevel = 1;
+
+        static BonusStageConfig& getInstance()
+        {
+            static BonusStageConfig instance;
+            return instance;
+        }
+    };
+
     class BonusStageState : public State
     {
     public:

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -6,6 +6,7 @@
 #include "GameOptionsState.h"
 #include "StageIntroState.h"
 #include "StageSummaryState.h"
+#include "BonusStageState.h"
 
 namespace FishGame
 {
@@ -224,8 +225,8 @@ namespace FishGame
         // Register bonus stage
         m_stateFactories[StateID::BonusStage] = [this]() -> std::unique_ptr<State>
             {
-                // Default to feeding frenzy, level 1
-                return std::make_unique<BonusStageState>(*this, BonusStageType::FeedingFrenzy, 1);
+                auto& cfg = BonusStageConfig::getInstance();
+                return std::make_unique<BonusStageState>(*this, cfg.type, cfg.playerLevel);
             };
 
         // TODO: Register additional states as they are implemented

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -1152,6 +1152,9 @@ namespace FishGame
 
                 deferAction([this, bonusType]() {
                     m_returningFromBonusStage = true;
+                    auto& cfg = BonusStageConfig::getInstance();
+                    cfg.type = bonusType;
+                    cfg.playerLevel = m_savedLevel;
                     StageIntroState::configure(0, true, StateID::BonusStage);
                     requestStackPush(StateID::StageIntro);
                     });


### PR DESCRIPTION
## Summary
- add `BonusStageConfig` to pass type and level information
- use `BonusStageConfig` in `Game` state factory for dynamic bonus stages
- update `PlayState` to set upcoming bonus stage configuration before showing intro

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68614f93cf448333b52dbf71b1754600