### PR TITLE
Refactor PlayState into smaller systems

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -10,6 +10,9 @@
 #include "BonusItemManager.h"
 #include "OysterManager.h"
 #include "ScoreSystem.h"
+#include "HUDSystem.h"
+#include "ParticleSystem.h"
+#include "InputHandler.h"
 #include "PowerUp.h"
 #include "ExtendedPowerUps.h"
 #include "Hazard.h"
@@ -47,15 +50,6 @@ namespace FishGame
     private:
         // ==================== Type Definitions ====================
 
-        // Particle effect structure
-        struct ParticleEffect
-        {
-            sf::CircleShape shape;
-            sf::Vector2f velocity;
-            sf::Time lifetime;
-            float alpha = 0.f;
-        };
-
         // Game state tracking
         struct GameStateData
         {
@@ -70,17 +64,6 @@ namespace FishGame
         };
 
         // HUD elements collection
-        struct HUDElements
-        {
-            sf::Text scoreText;
-            sf::Text livesText;
-            sf::Text levelText;
-            sf::Text fpsText;
-            sf::Text messageText;
-            sf::Text chainText;
-            sf::Text powerUpText;
-            sf::Text effectsText;
-        };
 
         // Performance metrics
         struct PerformanceMetrics
@@ -133,7 +116,6 @@ namespace FishGame
 
         // Initialization
         void initializeSystems();
-        void initializeHUD();
         template<typename SystemType>
         SystemType* createAndStoreSystem(const std::string& name, const sf::Font& font);
 
@@ -168,7 +150,6 @@ namespace FishGame
         void applyFreeze();
         void reverseControls();
         void showMessage(const std::string& message);
-        void centerText(sf::Text& text);
         void updateBackground(int level);
 
     private:
@@ -196,7 +177,7 @@ namespace FishGame
 
         // State tracking
         GameStateData m_gameState;
-        HUDElements m_hud;
+        std::unique_ptr<HUDSystem> m_hudSystem;
         std::unordered_map<TextureID, int> m_levelCounts;
 
         // Effect states
@@ -208,6 +189,7 @@ namespace FishGame
         sf::Time m_stunTimer;
         sf::Time m_hazardSpawnTimer;
         sf::Time m_extendedPowerUpSpawnTimer;
+        InputHandler m_inputHandler;
 
         // Bonus stage tracking
         bool m_bonusStageTriggered;
@@ -217,8 +199,7 @@ namespace FishGame
         // Performance tracking
         PerformanceMetrics m_metrics;
 
-        // Visual effects
-        std::vector<ParticleEffect> m_particles;
+        std::unique_ptr<ParticleSystem> m_particleSystem;
 
         // Camera and background
         sf::Sprite m_backgroundSprite;

--- a/include/Systems/HUDSystem.h
+++ b/include/Systems/HUDSystem.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <unordered_map>
+#include <string>
+#include "GameConstants.h"
+#include "PowerUp.h"
+
+namespace FishGame
+{
+    class HUDSystem : public sf::Drawable
+    {
+    public:
+        HUDSystem(const sf::Font& font, const sf::Vector2u& windowSize);
+
+        void update(int score, int lives, int level, int chainBonus,
+            const std::vector<PowerUpType>& activePowerUps,
+            bool playerFrozen, sf::Time freezeTime,
+            bool reversed, sf::Time reverseTime,
+            bool stunned, sf::Time stunTime,
+            float fps);
+
+        void showMessage(const std::string& message);
+        void clearMessage();
+
+    protected:
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+
+    private:
+        void initText(sf::Text& text, unsigned int size, const sf::Vector2f& pos,
+            const sf::Color& color = Constants::HUD_TEXT_COLOR);
+
+        sf::Text m_scoreText;
+        sf::Text m_livesText;
+        sf::Text m_levelText;
+        sf::Text m_chainText;
+        sf::Text m_powerUpText;
+        sf::Text m_fpsText;
+        sf::Text m_effectsText;
+        sf::Text m_messageText;
+
+        const sf::Font& m_font;
+        sf::Vector2u m_windowSize;
+    };
+}

--- a/include/Systems/InputHandler.h
+++ b/include/Systems/InputHandler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <SFML/Window/Event.hpp>
+
+namespace FishGame
+{
+    class InputHandler
+    {
+    public:
+        void setReversed(bool reversed) { m_reversed = reversed; }
+        void processEvent(sf::Event event, std::function<void(const sf::Event&)> callback);
+    private:
+        bool m_reversed{false};
+    };
+}

--- a/include/Systems/ParticleSystem.h
+++ b/include/Systems/ParticleSystem.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <vector>
+#include "GameConstants.h"
+
+namespace FishGame
+{
+    struct Particle
+    {
+        sf::CircleShape shape;
+        sf::Vector2f velocity;
+        sf::Time lifetime;
+        float alpha = 0.f;
+    };
+
+    class ParticleSystem : public sf::Drawable
+    {
+    public:
+        ParticleSystem();
+        void update(sf::Time dt);
+        void createEffect(const sf::Vector2f& pos, const sf::Color& color, int count = Constants::DEFAULT_PARTICLE_COUNT);
+        void clear() { m_particles.clear(); }
+
+    protected:
+        void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+
+    private:
+        std::vector<Particle> m_particles;
+        std::mt19937 m_rng;
+        std::uniform_real_distribution<float> m_angleDist;
+        std::uniform_real_distribution<float> m_speedDist;
+    };
+}

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -35,7 +35,6 @@ namespace FishGame
         , m_bonusItemManager(nullptr)
         , m_oysterManager(nullptr)
         , m_gameState()
-        , m_hud()
         , m_isPlayerFrozen(false)
         , m_hasControlsReversed(false)
         , m_isPlayerStunned(false)
@@ -48,7 +47,7 @@ namespace FishGame
         , m_returningFromBonusStage(false)
         , m_savedLevel(1)
         , m_metrics()
-        , m_particles()
+        , m_particleSystem(std::make_unique<ParticleSystem>())
         , m_randomEngine(std::random_device{}())
         , m_angleDist(0.0f, 360.0f)
         , m_speedDist(Constants::MIN_PARTICLE_SPEED, Constants::MAX_PARTICLE_SPEED)
@@ -67,7 +66,6 @@ namespace FishGame
         m_entities.reserve(Constants::MAX_ENTITIES);
         m_bonusItems.reserve(Constants::MAX_BONUS_ITEMS);
         m_hazards.reserve(20);
-        m_particles.reserve(Constants::MAX_PARTICLES);
 
         // Setup background and camera
         auto& window = getGame().getWindow();
@@ -156,77 +154,24 @@ namespace FishGame
         m_growthMeter->setPosition(growthMeterX, growthMeterY);
         m_frenzySystem->setPosition(window.getSize().x / 2.0f, Constants::FRENZY_Y_POSITION);
 
-        // Initialize HUD
-        initializeHUD();
+        // Initialize HUD system
+        auto& font = getGame().getFonts().get(Fonts::Main);
+        m_hudSystem = std::make_unique<HUDSystem>(font, window.getSize());
 
         // Configure initial state
         m_fishSpawner->setLevel(m_gameState.currentLevel);
 
-        updateHUD();
     }
 
-    void PlayState::initializeHUD()
-    {
-        auto& font = getGame().getFonts().get(Fonts::Main);
-        auto& window = getGame().getWindow();
-
-        // Lambda for initializing text objects
-        auto initText = [&font](sf::Text& text, unsigned int size, const sf::Vector2f& position,
-            const sf::Color& color = Constants::HUD_TEXT_COLOR) {
-                text.setFont(font);
-                text.setCharacterSize(size);
-                text.setFillColor(color);
-                text.setPosition(position);
-            };
-
-        // Initialize HUD texts
-        initText(m_hud.scoreText, Constants::HUD_FONT_SIZE,
-            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN));
-        initText(m_hud.livesText, Constants::HUD_FONT_SIZE,
-            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING));
-        initText(m_hud.levelText, Constants::HUD_FONT_SIZE,
-            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING * 2));
-        initText(m_hud.chainText, Constants::HUD_SMALL_FONT_SIZE,
-            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING * 3));
-        initText(m_hud.powerUpText, Constants::HUD_SMALL_FONT_SIZE,
-            sf::Vector2f(window.getSize().x - Constants::POWERUP_TEXT_X_OFFSET, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING));
-        initText(m_hud.fpsText, Constants::HUD_FONT_SIZE,
-            sf::Vector2f(window.getSize().x - Constants::FPS_TEXT_X_OFFSET, Constants::HUD_MARGIN));
-        initText(m_hud.effectsText, 18,
-            sf::Vector2f(Constants::HUD_EFFECTS_TEXT_X,
-                window.getSize().y - Constants::HUD_EFFECTS_TEXT_Y_OFFSET),
-            sf::Color::Yellow);
-
-        // Special handling for message text
-        m_hud.messageText.setFont(font);
-        m_hud.messageText.setCharacterSize(Constants::MESSAGE_FONT_SIZE);
-        m_hud.messageText.setFillColor(Constants::MESSAGE_COLOR);
-        m_hud.messageText.setOutlineColor(Constants::MESSAGE_OUTLINE_COLOR);
-        m_hud.messageText.setOutlineThickness(Constants::MESSAGE_OUTLINE_THICKNESS);
-    }
 
     void PlayState::handleEvent(const sf::Event& event)
     {
         if (m_isPlayerStunned || getGame().getCurrentState<StageIntroState>())
             return;
 
-        // Handle controls reversal
-        sf::Event processedEvent = event;
-        if (m_hasControlsReversed && event.type == sf::Event::KeyPressed)
+        m_inputHandler.setReversed(m_hasControlsReversed);
+        m_inputHandler.processEvent(event, [this](const sf::Event& processedEvent)
         {
-            static const std::unordered_map<sf::Keyboard::Key, sf::Keyboard::Key> reverseMap = {
-                {sf::Keyboard::W, sf::Keyboard::S}, {sf::Keyboard::S, sf::Keyboard::W},
-                {sf::Keyboard::A, sf::Keyboard::D}, {sf::Keyboard::D, sf::Keyboard::A},
-                {sf::Keyboard::Up, sf::Keyboard::Down}, {sf::Keyboard::Down, sf::Keyboard::Up},
-                {sf::Keyboard::Left, sf::Keyboard::Right}, {sf::Keyboard::Right, sf::Keyboard::Left}
-            };
-
-            if (auto it = reverseMap.find(event.key.code); it != reverseMap.end())
-            {
-                processedEvent.key.code = it->second;
-            }
-        }
-
         switch (processedEvent.type)
         {
         case sf::Event::KeyPressed:
@@ -279,7 +224,8 @@ namespace FishGame
         default:
             break;
         }
-    }
+    });
+}
 
     bool PlayState::update(sf::Time deltaTime)
     {
@@ -383,17 +329,8 @@ namespace FishGame
         auto newItems = m_bonusItemManager->collectSpawnedItems();
         std::move(newItems.begin(), newItems.end(), std::back_inserter(m_bonusItems));
 
-        // Update particles with parallel execution
-        std::for_each(std::execution::par_unseq,
-            m_particles.begin(), m_particles.end(),
-            [deltaTime](ParticleEffect& particle) {
-                particle.lifetime -= deltaTime;
-                particle.shape.move(particle.velocity * deltaTime.asSeconds());
-                particle.alpha = std::max(0.0f, particle.alpha - Constants::PARTICLE_FADE_RATE * deltaTime.asSeconds());
-                sf::Color color = particle.shape.getFillColor();
-                color.a = static_cast<sf::Uint8>(particle.alpha);
-                particle.shape.setFillColor(color);
-            });
+        // Update particles
+        m_particleSystem->update(deltaTime);
 
         // Remove dead entities from all containers
         EntityUtils::removeDeadEntities(m_entities);
@@ -408,14 +345,6 @@ namespace FishGame
             m_bonusItems.end()
         );
 
-        // Remove expired particles
-        m_particles.erase(
-            std::remove_if(m_particles.begin(), m_particles.end(),
-                [](const auto& particle) {
-                    return particle.lifetime <= sf::Time::Zero;
-                }),
-            m_particles.end()
-        );
 
         // Check collisions
         checkCollisions();
@@ -1064,7 +993,7 @@ namespace FishGame
         resetLevel();
         updateLevelDifficulty();
 
-        m_hud.messageText.setString("");
+        m_hudSystem->clearMessage();
         m_bonusStageTriggered = false;
 
         StageIntroState::configure(m_gameState.currentLevel, false);
@@ -1087,7 +1016,7 @@ namespace FishGame
         m_entities.clear();
         m_bonusItems.clear();
         m_hazards.clear();
-        m_particles.clear();
+        m_particleSystem->clear();
 
         m_scoreSystem->reset();
         m_frenzySystem->reset();
@@ -1164,98 +1093,22 @@ namespace FishGame
 
     void PlayState::createParticleEffect(const sf::Vector2f& position, const sf::Color& color, int count)
     {
-        m_particles.reserve(m_particles.size() + count);
-
-        std::generate_n(std::back_inserter(m_particles), count,
-            [this, &position, &color]() {
-                ParticleEffect particle;
-                particle.shape = sf::CircleShape(Constants::PARTICLE_RADIUS);
-                particle.shape.setFillColor(color);
-                particle.shape.setPosition(position);
-
-                float angle = m_angleDist(m_randomEngine) * Constants::DEG_TO_RAD;
-                float speed = m_speedDist(m_randomEngine);
-                particle.velocity = sf::Vector2f(std::cos(angle) * speed, std::sin(angle) * speed);
-
-                particle.lifetime = sf::seconds(Constants::PARTICLE_LIFETIME);
-                particle.alpha = Constants::PARTICLE_INITIAL_ALPHA;
-
-                return particle;
-            });
+        m_particleSystem->createEffect(position, color, count);
     }
 
     void PlayState::updateHUD()
     {
-        auto formatText = [](sf::Text& text, const auto&... args) {
-            std::ostringstream stream;
-            ((stream << args), ...);
-            text.setString(stream.str());
-            };
-
-        formatText(m_hud.scoreText,
-            "Score: ", m_scoreSystem->getCurrentScore());
-
-        formatText(m_hud.livesText, "Lives: ", m_gameState.playerLives);
-
-        formatText(m_hud.levelText,
-            "Level: ", m_gameState.currentLevel,
-            m_gameState.gameWon ? " | COMPLETE!" : "");
-
-        if (m_scoreSystem->getChainBonus() > 0)
-        {
-            formatText(m_hud.chainText, "Chain Bonus: +", m_scoreSystem->getChainBonus());
-        }
-        else
-        {
-            m_hud.chainText.setString("");
-        }
-
         auto activePowerUps = m_powerUpManager->getActivePowerUps();
-        if (!activePowerUps.empty())
-        {
-            std::ostringstream powerUpStream;
-            powerUpStream << "\nActive Power-Ups:\n";
-
-            std::for_each(activePowerUps.begin(), activePowerUps.end(),
-                [this, &powerUpStream](PowerUpType type) {
-                    // Create local map to avoid static const capture issue
-                    std::unordered_map<PowerUpType, std::string> names = {
-                        {PowerUpType::ScoreDoubler, "2X Score"},
-                        {PowerUpType::SpeedBoost, "Speed Boost"},
-                        {PowerUpType::Freeze, "Freeze"}
-                    };
-
-                    if (auto it = names.find(type); it != names.end())
-                    {
-                        powerUpStream << it->second;
-                        sf::Time remaining = m_powerUpManager->getRemainingTime(type);
-                        if (remaining > sf::Time::Zero)
-                        {
-                            powerUpStream << " - " << std::fixed << std::setprecision(1)
-                                << remaining.asSeconds() << "s";
-                        }
-                        powerUpStream << "\n";
-                    }
-                });
-
-            m_hud.powerUpText.setString(powerUpStream.str());
-        }
-        else
-        {
-            m_hud.powerUpText.setString("");
-        }
-
-        std::ostringstream effectStream;
-        if (m_isPlayerFrozen)
-            effectStream << "FREEZE ACTIVE: " << std::fixed << std::setprecision(1)
-            << m_freezeTimer.asSeconds() << "s\n";
-        if (m_hasControlsReversed)
-            effectStream << "CONTROLS REVERSED: " << std::fixed << std::setprecision(1)
-            << m_controlReverseTimer.asSeconds() << "s\n";
-        if (m_isPlayerStunned)
-            effectStream << "STUNNED: " << std::fixed << std::setprecision(1)
-            << m_stunTimer.asSeconds() << "s\n";
-        m_hud.effectsText.setString(effectStream.str());
+        m_hudSystem->update(
+            m_scoreSystem->getCurrentScore(),
+            m_gameState.playerLives,
+            m_gameState.currentLevel,
+            m_scoreSystem->getChainBonus(),
+            activePowerUps,
+            m_isPlayerFrozen, m_freezeTimer,
+            m_hasControlsReversed, m_controlReverseTimer,
+            m_isPlayerStunned, m_stunTimer,
+            m_metrics.currentFPS);
     }
 
     void PlayState::updatePerformanceMetrics(sf::Time deltaTime)
@@ -1270,9 +1123,7 @@ namespace FishGame
             m_metrics.frameCount = 0;
             m_metrics.fpsUpdateTime = sf::Time::Zero;
 
-            std::ostringstream fpsStream;
-            fpsStream << std::fixed << std::setprecision(1) << "FPS: " << m_metrics.currentFPS;
-            m_hud.fpsText.setString(fpsStream.str());
+            // FPS value stored for HUD system
         }
     }
 
@@ -1317,16 +1168,7 @@ namespace FishGame
 
     void PlayState::showMessage(const std::string& message)
     {
-        m_hud.messageText.setString(message);
-        centerText(m_hud.messageText);
-    }
-
-void PlayState::centerText(sf::Text& text)
-{
-        sf::FloatRect bounds = text.getLocalBounds();
-        text.setOrigin(bounds.width / 2.0f, bounds.height / 2.0f);
-        auto windowSize = getGame().getWindow().getSize();
-        text.setPosition(windowSize.x / 2.0f, windowSize.y / 2.0f);
+        m_hudSystem->showMessage(message);
     }
 
     void PlayState::render()
@@ -1348,10 +1190,7 @@ void PlayState::centerText(sf::Text& text)
 
         window.draw(*m_player);
 
-        std::for_each(m_particles.begin(), m_particles.end(),
-            [&window](const ParticleEffect& particle) {
-                window.draw(particle.shape);
-            });
+        window.draw(*m_particleSystem);
 
         m_scoreSystem->drawFloatingScores(window);
         
@@ -1361,19 +1200,15 @@ void PlayState::centerText(sf::Text& text)
 
 
 
-        // Render HUD texts
-        window.draw(m_hud.scoreText);
-        window.draw(m_hud.livesText);
-        window.draw(m_hud.levelText);
-        window.draw(m_hud.chainText);
-        window.draw(m_hud.powerUpText);
+        // Render HUD
+        window.draw(*m_hudSystem);
 
         if (m_gameState.gameWon || m_gameState.levelComplete)
         {
             sf::RectangleShape overlay(sf::Vector2f(window.getSize()));
             overlay.setFillColor(Constants::OVERLAY_COLOR);
             window.draw(overlay);
-            window.draw(m_hud.messageText);
+            // message rendered via HUD system
         }
     }
 
@@ -1396,7 +1231,7 @@ void PlayState::centerText(sf::Text& text)
 
             // Mouse control disabled
 
-            m_hud.messageText.setString("");
+            m_hudSystem->clearMessage();
             m_initialized = true;
             getGame().getMusicPlayer().play(musicForLevel(m_gameState.currentLevel), true);
         }

--- a/src/Systems/HUDSystem.cpp
+++ b/src/Systems/HUDSystem.cpp
@@ -1,0 +1,134 @@
+#include "HUDSystem.h"
+#include <sstream>
+#include <iomanip>
+
+namespace FishGame
+{
+    HUDSystem::HUDSystem(const sf::Font& font, const sf::Vector2u& windowSize)
+        : m_font(font), m_windowSize(windowSize)
+    {
+        initText(m_scoreText, Constants::HUD_FONT_SIZE,
+            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN));
+        initText(m_livesText, Constants::HUD_FONT_SIZE,
+            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING));
+        initText(m_levelText, Constants::HUD_FONT_SIZE,
+            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING * 2));
+        initText(m_chainText, Constants::HUD_SMALL_FONT_SIZE,
+            sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING * 3));
+        initText(m_powerUpText, Constants::HUD_SMALL_FONT_SIZE,
+            sf::Vector2f(windowSize.x - Constants::POWERUP_TEXT_X_OFFSET, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING));
+        initText(m_fpsText, Constants::HUD_FONT_SIZE,
+            sf::Vector2f(windowSize.x - Constants::FPS_TEXT_X_OFFSET, Constants::HUD_MARGIN));
+        initText(m_effectsText, 18,
+            sf::Vector2f(Constants::HUD_EFFECTS_TEXT_X,
+                windowSize.y - Constants::HUD_EFFECTS_TEXT_Y_OFFSET), sf::Color::Yellow);
+
+        m_messageText.setFont(font);
+        m_messageText.setCharacterSize(Constants::MESSAGE_FONT_SIZE);
+        m_messageText.setFillColor(Constants::MESSAGE_COLOR);
+        m_messageText.setOutlineColor(Constants::MESSAGE_OUTLINE_COLOR);
+        m_messageText.setOutlineThickness(Constants::MESSAGE_OUTLINE_THICKNESS);
+    }
+
+    void HUDSystem::update(int score, int lives, int level, int chainBonus,
+        const std::vector<PowerUpType>& activePowerUps,
+        bool frozen, sf::Time freezeTime,
+        bool reversed, sf::Time reverseTime,
+        bool stunned, sf::Time stunTime,
+        float fps)
+    {
+        std::ostringstream stream;
+        stream << "Score: " << score;
+        m_scoreText.setString(stream.str());
+
+        stream.str(""); stream.clear();
+        stream << "Lives: " << lives;
+        m_livesText.setString(stream.str());
+
+        stream.str(""); stream.clear();
+        stream << "Level: " << level;
+        m_levelText.setString(stream.str());
+
+        if (chainBonus > 0)
+        {
+            stream.str(""); stream.clear();
+            stream << "Chain Bonus: +" << chainBonus;
+            m_chainText.setString(stream.str());
+        }
+        else
+        {
+            m_chainText.setString("");
+        }
+
+        if (!activePowerUps.empty())
+        {
+            stream.str(""); stream.clear();
+            stream << "\nActive Power-Ups:\n";
+            for (PowerUpType type : activePowerUps)
+            {
+                static std::unordered_map<PowerUpType,std::string> names = {
+                    {PowerUpType::ScoreDoubler, "2X Score"},
+                    {PowerUpType::SpeedBoost, "Speed Boost"},
+                    {PowerUpType::Freeze, "Freeze"}
+                };
+                if (auto it = names.find(type); it != names.end())
+                    stream << it->second << "\n";
+            }
+            m_powerUpText.setString(stream.str());
+        }
+        else
+        {
+            m_powerUpText.setString("");
+        }
+
+        stream.str(""); stream.clear();
+        stream << std::fixed << std::setprecision(1) << "FPS: " << fps;
+        m_fpsText.setString(stream.str());
+
+        stream.str(""); stream.clear();
+        if (frozen)
+            stream << "FREEZE ACTIVE: " << std::fixed << std::setprecision(1)
+                << freezeTime.asSeconds() << "s\n";
+        if (reversed)
+            stream << "CONTROLS REVERSED: " << std::fixed << std::setprecision(1)
+                << reverseTime.asSeconds() << "s\n";
+        if (stunned)
+            stream << "STUNNED: " << std::fixed << std::setprecision(1)
+                << stunTime.asSeconds() << "s\n";
+        m_effectsText.setString(stream.str());
+    }
+
+    void HUDSystem::showMessage(const std::string& message)
+    {
+        m_messageText.setString(message);
+        sf::FloatRect bounds = m_messageText.getLocalBounds();
+        m_messageText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+        m_messageText.setPosition(m_windowSize.x / 2.f, m_windowSize.y / 2.f);
+    }
+
+    void HUDSystem::clearMessage()
+    {
+        m_messageText.setString("");
+    }
+
+    void HUDSystem::initText(sf::Text& text, unsigned int size, const sf::Vector2f& pos, const sf::Color& color)
+    {
+        text.setFont(m_font);
+        text.setCharacterSize(size);
+        text.setFillColor(color);
+        text.setPosition(pos);
+    }
+
+    void HUDSystem::draw(sf::RenderTarget& target, sf::RenderStates states) const
+    {
+        target.draw(m_scoreText, states);
+        target.draw(m_livesText, states);
+        target.draw(m_levelText, states);
+        target.draw(m_chainText, states);
+        target.draw(m_powerUpText, states);
+        target.draw(m_fpsText, states);
+        target.draw(m_effectsText, states);
+        if (!m_messageText.getString().isEmpty())
+            target.draw(m_messageText, states);
+    }
+}

--- a/src/Systems/InputHandler.cpp
+++ b/src/Systems/InputHandler.cpp
@@ -1,0 +1,21 @@
+#include "InputHandler.h"
+#include <unordered_map>
+
+namespace FishGame
+{
+    void InputHandler::processEvent(sf::Event event, std::function<void(const sf::Event&)> callback)
+    {
+        if (m_reversed && event.type == sf::Event::KeyPressed)
+        {
+            static const std::unordered_map<sf::Keyboard::Key, sf::Keyboard::Key> map = {
+                {sf::Keyboard::W, sf::Keyboard::S}, {sf::Keyboard::S, sf::Keyboard::W},
+                {sf::Keyboard::A, sf::Keyboard::D}, {sf::Keyboard::D, sf::Keyboard::A},
+                {sf::Keyboard::Up, sf::Keyboard::Down}, {sf::Keyboard::Down, sf::Keyboard::Up},
+                {sf::Keyboard::Left, sf::Keyboard::Right}, {sf::Keyboard::Right, sf::Keyboard::Left}
+            };
+            if (auto it = map.find(event.key.code); it != map.end())
+                event.key.code = it->second;
+        }
+        callback(event);
+    }
+}

--- a/src/Systems/ParticleSystem.cpp
+++ b/src/Systems/ParticleSystem.cpp
@@ -1,0 +1,56 @@
+#include "ParticleSystem.h"
+#include <algorithm>
+#include <execution>
+#include <cmath>
+
+namespace FishGame
+{
+    ParticleSystem::ParticleSystem()
+        : m_particles()
+        , m_rng(std::random_device{}())
+        , m_angleDist(0.f, 360.f)
+        , m_speedDist(Constants::MIN_PARTICLE_SPEED, Constants::MAX_PARTICLE_SPEED)
+    {
+        m_particles.reserve(Constants::MAX_PARTICLES);
+    }
+
+    void ParticleSystem::update(sf::Time dt)
+    {
+        std::for_each(std::execution::par_unseq,
+            m_particles.begin(), m_particles.end(),
+            [dt](Particle& p) {
+                p.lifetime -= dt;
+                p.shape.move(p.velocity * dt.asSeconds());
+                p.alpha = std::max(0.f, p.alpha - Constants::PARTICLE_FADE_RATE * dt.asSeconds());
+                sf::Color c = p.shape.getFillColor();
+                c.a = static_cast<sf::Uint8>(p.alpha);
+                p.shape.setFillColor(c);
+            });
+        m_particles.erase(std::remove_if(m_particles.begin(), m_particles.end(),
+            [](const Particle& p){ return p.lifetime <= sf::Time::Zero; }), m_particles.end());
+    }
+
+    void ParticleSystem::createEffect(const sf::Vector2f& pos, const sf::Color& color, int count)
+    {
+        m_particles.reserve(m_particles.size() + count);
+        for(int i=0;i<count;++i)
+        {
+            Particle p;
+            p.shape = sf::CircleShape(Constants::PARTICLE_RADIUS);
+            p.shape.setFillColor(color);
+            p.shape.setPosition(pos);
+            float angle = m_angleDist(m_rng) * Constants::DEG_TO_RAD;
+            float speed = m_speedDist(m_rng);
+            p.velocity = {std::cos(angle)*speed, std::sin(angle)*speed};
+            p.lifetime = sf::seconds(Constants::PARTICLE_LIFETIME);
+            p.alpha = Constants::PARTICLE_INITIAL_ALPHA;
+            m_particles.push_back(p);
+        }
+    }
+
+    void ParticleSystem::draw(sf::RenderTarget& target, sf::RenderStates states) const
+    {
+        for(const auto& p : m_particles)
+            target.draw(p.shape, states);
+    }
+}


### PR DESCRIPTION
## Summary
- split HUD management into new `HUDSystem`
- handle generic particle effects via `ParticleSystem`
- reverse control logic using `InputHandler`
- delegate `PlayState` to these new systems

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_686156d4fe988333bdae81d6e35257e4