### PR TITLE
Fix Player missing methods

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -50,6 +50,7 @@ namespace FishGame
         void addPoints(int points);
         void resetSize();
         void fullReset();
+        void checkStageAdvancement();
 
         // Points tracking
         int getPoints() const { return m_points; }
@@ -88,6 +89,9 @@ namespace FishGame
         // Visual effects
         void triggerEatEffect();
         void triggerDamageEffect();
+
+    private:
+        void updateVisualEffects(sf::Time deltaTime);
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -459,25 +459,28 @@ void Player::applyPoisonEffect(sf::Time duration)
         m_soundPlayer->play(SoundEffectID::PlayerPoison);
 }
 
-    void Player::triggerEatEffect()
-    {
-        if (m_visual)
-            m_visual->triggerEatEffect();
-    }
-    void Player::triggerDamageEffect()
-    {
-        if (m_visual)
-            m_visual->triggerDamageEffect();
-    }
-    {
-        m_windowBounds = windowSize;
-    }
+void Player::triggerEatEffect()
+{
+    if (m_visual)
+        m_visual->triggerEatEffect();
+}
 
-    void Player::draw(sf::RenderTarget& target, sf::RenderStates states) const
-    {
-        if (m_visual)
-            m_visual->draw(target, states);
-    }
+void Player::triggerDamageEffect()
+{
+    if (m_visual)
+        m_visual->triggerDamageEffect();
+}
+
+void Player::setWindowBounds(const sf::Vector2u& windowSize)
+{
+    m_windowBounds = windowSize;
+}
+
+void Player::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    if (m_visual)
+        m_visual->draw(target, states);
+}
     void Player::constrainToWindow()
     {
         m_position.x = std::clamp(m_position.x, m_radius,


### PR DESCRIPTION
## Summary
- declare `checkStageAdvancement` and `updateVisualEffects`
- implement `setWindowBounds`
- route visual effect calls through `PlayerVisual`

## Testing
- `cmake -S . -B build` *(fails: Could not find SFMLConfig.cmake)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68615f6458c88333b925506077d29c99