### PR TITLE
Fix Player destructor and include for PlayerVisual

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -25,7 +25,7 @@ namespace FishGame
         friend class PlayerVisual;
     public:
         Player();
-        ~Player() override = default;
+        ~Player() override;
 
         // Entity interface implementation
         void update(sf::Time deltaTime) override;

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -22,6 +22,8 @@ namespace FishGame
     const sf::Time Player::m_eatAnimationDuration = sf::seconds(0.3f);
     const sf::Time Player::m_turnAnimationDuration = sf::seconds(0.45f);
 
+    Player::~Player() = default;
+
     Player::Player()
         : Entity()
         , m_score(0)

--- a/src/Entities/PlayerGrowth.cpp
+++ b/src/Entities/PlayerGrowth.cpp
@@ -1,5 +1,6 @@
 #include "PlayerGrowth.h"
 #include "Player.h"
+#include "PlayerVisual.h"
 #include <cmath>
 
 namespace FishGame {


### PR DESCRIPTION
## Summary
- declare `Player` destructor in header and define in cpp
- include `PlayerVisual.h` in `PlayerGrowth.cpp`
- build project to ensure compilation succeeds

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_686160bdfed483339db1e2e89b4036ef