### PR TITLE
Introduce state manager

### DIFF
--- a/include/Core/Game.h
+++ b/include/Core/Game.h
@@ -2,9 +2,8 @@
 
 #include "MusicPlayer.h"
 #include "State.h"
+#include "StateManager.h"
 #include "Player.h"
-#include <functional>
-#include <unordered_map>
 
 namespace FishGame
 {
@@ -44,11 +43,8 @@ namespace FishGame
             static_assert(std::is_base_of_v<State, StateType>,
                 "StateType must be derived from State");
 
-            if (!m_stateStack.empty())
-            {
-                return dynamic_cast<StateType*>(m_stateStack.back().get());
-            }
-            return nullptr;
+            return m_stateManager.getCurrentState<StateType>();
+            
         }
 
     private:
@@ -63,21 +59,12 @@ namespace FishGame
         // State management
         void registerStates();
         void applyPendingStateChanges();
-
-        // Template method for state registration
+        
         template<typename T>
         void registerState(StateID id)
         {
-            static_assert(std::is_base_of_v<State, T>,
-                "T must be derived from State");
-
-            m_stateFactories[id] = [this]() -> std::unique_ptr<State>
-                {
-                    return std::make_unique<T>(*this);
-                };
+            m_stateManager.registerState<T>(id);
         }
-
-        std::unique_ptr<State> createState(StateID id);
 
     private:
         // Window and timing constants from GameConstants.h
@@ -91,13 +78,8 @@ namespace FishGame
         FontHolder m_fonts;
         std::unique_ptr<ResourceHolder<sf::Texture, TextureID>> m_spriteTextures;
 
-        // State management using STL containers
-        using StatePtr = std::unique_ptr<State>;
-        using StateFactory = std::function<StatePtr()>;
-
-        std::vector<StatePtr> m_stateStack;
-        std::vector<std::pair<StateAction, StateID>> m_pendingList;
-        std::unordered_map<StateID, StateFactory> m_stateFactories;
+        // State manager
+        StateManager m_stateManager;
 
         std::unique_ptr<SpriteManager> m_spriteManager;
         std::unique_ptr<MusicPlayer> m_musicPlayer;

--- a/include/Core/StateManager.h
+++ b/include/Core/StateManager.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "State.h"
+#include "GameExceptions.h"
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace FishGame
+{
+    class Game;
+
+    class StateManager
+    {
+    public:
+        using StatePtr = std::unique_ptr<State>;
+        using StateFactory = std::function<StatePtr()>;
+
+        explicit StateManager(Game& game);
+        ~StateManager() = default;
+
+        StateManager(const StateManager&) = delete;
+        StateManager& operator=(const StateManager&) = delete;
+        StateManager(StateManager&&) = delete;
+        StateManager& operator=(StateManager&&) = delete;
+
+        void pushState(StateID id);
+        void popState();
+        void clearStates();
+
+        template<typename StateType>
+        StateType* getCurrentState() const
+        {
+            static_assert(std::is_base_of_v<State, StateType>,
+                "StateType must be derived from State");
+
+            if (!m_stateStack.empty())
+            {
+                return dynamic_cast<StateType*>(m_stateStack.back().get());
+            }
+            return nullptr;
+        }
+
+        template<typename T>
+        void registerState(StateID id)
+        {
+            static_assert(std::is_base_of_v<State, T>,
+                "T must be derived from State");
+
+            m_stateFactories[id] = [this]() -> StatePtr
+            {
+                return std::make_unique<T>(m_game);
+            };
+        }
+
+        void registerState(StateID id, StateFactory factory)
+        {
+            m_stateFactories[id] = std::move(factory);
+        }
+
+        void applyPendingChanges();
+
+        bool empty() const { return m_stateStack.empty(); }
+        const auto& getStateStack() const { return m_stateStack; }
+
+    private:
+        StatePtr createState(StateID id);
+
+        Game& m_game;
+        std::vector<StatePtr> m_stateStack;
+        std::vector<std::pair<StateAction, StateID>> m_pendingList;
+        std::unordered_map<StateID, StateFactory> m_stateFactories;
+    };
+}

--- a/src/Core/StateManager.cpp
+++ b/src/Core/StateManager.cpp
@@ -1,0 +1,87 @@
+#include "StateManager.h"
+#include "Game.h"
+
+namespace FishGame
+{
+    StateManager::StateManager(Game& game)
+        : m_game(game)
+        , m_stateStack()
+        , m_pendingList()
+        , m_stateFactories()
+    {
+        m_stateStack.reserve(10);
+        m_pendingList.reserve(10);
+        m_stateFactories.reserve(10);
+    }
+
+    void StateManager::pushState(StateID id)
+    {
+        m_pendingList.emplace_back(StateAction::Push, id);
+    }
+
+    void StateManager::popState()
+    {
+        m_pendingList.emplace_back(StateAction::Pop, StateID::None);
+    }
+
+    void StateManager::clearStates()
+    {
+        m_pendingList.emplace_back(StateAction::Clear, StateID::None);
+    }
+
+    void StateManager::applyPendingChanges()
+    {
+        for (const auto& pending : m_pendingList)
+        {
+            const auto& action = pending.first;
+            StateID stateID = pending.second;
+
+            switch (action)
+            {
+            case StateAction::Push:
+            {
+                auto newState = createState(stateID);
+                newState->onActivate();
+                m_stateStack.push_back(std::move(newState));
+            }
+            break;
+
+            case StateAction::Pop:
+                if (!m_stateStack.empty())
+                {
+                    m_stateStack.back()->onDeactivate();
+                    m_stateStack.pop_back();
+
+                    if (!m_stateStack.empty())
+                    {
+                        m_stateStack.back()->onActivate();
+                    }
+                }
+                break;
+
+            case StateAction::Clear:
+                while (!m_stateStack.empty())
+                {
+                    m_stateStack.back()->onDeactivate();
+                    m_stateStack.pop_back();
+                }
+                break;
+            }
+        }
+
+        m_pendingList.clear();
+    }
+
+    StateManager::StatePtr StateManager::createState(StateID id)
+    {
+        auto found = m_stateFactories.find(id);
+        if (found == m_stateFactories.end())
+        {
+            throw StateNotFoundException(
+                "State factory not found for StateID: " +
+                std::to_string(static_cast<int>(id)));
+        }
+
+        return found->second();
+    }
+}


### PR DESCRIPTION
## Summary
- create `StateManager` to own state stack and factories
- delegate push/pop/clear operations from `Game` to `StateManager`
- move state creation and registration through the manager

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68615c47222c8333a8e6d37f4da7b714