### PR TITLE
Refactor system initialization in PlayState

### DIFF
--- a/include/States/GameSystems.h
+++ b/include/States/GameSystems.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "GrowthMeter.h"
+#include "FrenzySystem.h"
+#include "PowerUp.h" // For PowerUpManager definition
+#include "ScoreSystem.h"
+#include "BonusItemManager.h"
+#include "OysterManager.h"
+
+namespace FishGame
+{
+    struct GameSystems
+    {
+        std::unique_ptr<GrowthMeter> growthMeter;
+        std::unique_ptr<FrenzySystem> frenzySystem;
+        std::unique_ptr<PowerUpManager> powerUpManager;
+        std::unique_ptr<ScoreSystem> scoreSystem;
+        std::unique_ptr<BonusItemManager> bonusItemManager;
+        std::unique_ptr<FixedOysterManager> oysterManager;
+
+        GameSystems() = default;
+
+        void initialize(const sf::Font& font, const sf::Vector2u& windowSize, SpriteManager& spriteManager)
+        {
+            growthMeter = std::make_unique<GrowthMeter>(font);
+            frenzySystem = std::make_unique<FrenzySystem>(font);
+            powerUpManager = std::make_unique<PowerUpManager>();
+            scoreSystem = std::make_unique<ScoreSystem>(font);
+            bonusItemManager = std::make_unique<BonusItemManager>(windowSize, font, spriteManager);
+            oysterManager = std::make_unique<FixedOysterManager>(windowSize, spriteManager);
+        }
+
+        GrowthMeter& getGrowthMeter() { return *growthMeter; }
+        FrenzySystem& getFrenzySystem() { return *frenzySystem; }
+        PowerUpManager& getPowerUpManager() { return *powerUpManager; }
+        ScoreSystem& getScoreSystem() { return *scoreSystem; }
+        BonusItemManager& getBonusItemManager() { return *bonusItemManager; }
+        FixedOysterManager& getOysterManager() { return *oysterManager; }
+    };
+}

--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -23,7 +23,7 @@
 #include <vector>
 #include <functional>
 #include <random>
-#include <unordered_map>
+#include "GameSystems.h"
 #include <optional>
 #include <algorithm>
 #include <numeric>
@@ -117,8 +117,6 @@ namespace FishGame
 
         // Initialization
         void initializeSystems();
-        template<typename SystemType>
-        SystemType* createAndStoreSystem(const std::string& name, const sf::Font& font);
 
         // Update methods
         void updateGameplay(sf::Time deltaTime);
@@ -166,15 +164,15 @@ namespace FishGame
         std::unique_ptr<EnvironmentSystem> m_environmentSystem;
 
         // Game systems
-        std::unordered_map<std::string, std::unique_ptr<void, std::function<void(void*)>>> m_systems;
+        GameSystems m_systems;
 
-        // Direct system pointers for performance
-        GrowthMeter* m_growthMeter;
-        FrenzySystem* m_frenzySystem;
-        PowerUpManager* m_powerUpManager;
-        ScoreSystem* m_scoreSystem;
-        BonusItemManager* m_bonusItemManager;
-        FixedOysterManager* m_oysterManager;
+        // Direct system pointers for convenience
+        GrowthMeter* m_growthMeter{nullptr};
+        FrenzySystem* m_frenzySystem{nullptr};
+        PowerUpManager* m_powerUpManager{nullptr};
+        ScoreSystem* m_scoreSystem{nullptr};
+        BonusItemManager* m_bonusItemManager{nullptr};
+        FixedOysterManager* m_oysterManager{nullptr};
 
         // State tracking
         GameStateData m_gameState;

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -80,51 +80,22 @@ namespace FishGame
         m_view.setCenter(m_worldSize * 0.5f);
     }
 
-    template<typename SystemType>
-    SystemType* PlayState::createAndStoreSystem(const std::string& name, const sf::Font& font)
-    {
-        auto system = std::make_unique<SystemType>(font);
-        SystemType* ptr = system.get();
-        m_systems[name] = std::unique_ptr<void, std::function<void(void*)>>(
-            system.release(),
-            [](void* p) { delete static_cast<SystemType*>(p); }
-        );
-        return ptr;
-    }
 
     void PlayState::initializeSystems()
     {
         auto& window = getGame().getWindow();
         auto& font = getGame().getFonts().get(Fonts::Main);
 
-        // Create game systems
-        m_growthMeter = createAndStoreSystem<GrowthMeter>("growth", font);
-        m_frenzySystem = createAndStoreSystem<FrenzySystem>("frenzy", font);
-        m_scoreSystem = createAndStoreSystem<ScoreSystem>("score", font);
+        // Create game systems through helper
+        m_systems.initialize(font, window.getSize(), getGame().getSpriteManager());
 
-        // Special initialization for other systems
-        auto powerUpManager = std::make_unique<PowerUpManager>();
-        m_powerUpManager = powerUpManager.get();
-        m_systems["powerup"] = std::unique_ptr<void, std::function<void(void*)>>(
-            powerUpManager.release(),
-            [](void* p) { delete static_cast<PowerUpManager*>(p); }
-        );
-
-        auto bonusManager = std::make_unique<BonusItemManager>(window.getSize(), font,
-            getGame().getSpriteManager());
-        m_bonusItemManager = bonusManager.get();
-        m_systems["bonus"] = std::unique_ptr<void, std::function<void(void*)>>(
-            bonusManager.release(),
-            [](void* p) { delete static_cast<BonusItemManager*>(p); }
-        );
-
-        auto oysterManager = std::make_unique<FixedOysterManager>(window.getSize(),
-            getGame().getSpriteManager());
-        m_oysterManager = oysterManager.get();
-        m_systems["oyster"] = std::unique_ptr<void, std::function<void(void*)>>(
-            oysterManager.release(),
-            [](void* p) { delete static_cast<FixedOysterManager*>(p); }
-        );
+        // Cache raw pointers for convenience
+        m_growthMeter = &m_systems.getGrowthMeter();
+        m_frenzySystem = &m_systems.getFrenzySystem();
+        m_powerUpManager = &m_systems.getPowerUpManager();
+        m_scoreSystem = &m_systems.getScoreSystem();
+        m_bonusItemManager = &m_systems.getBonusItemManager();
+        m_oysterManager = &m_systems.getOysterManager();
 
         // Initialize environment system
         m_environmentSystem->setEnvironment(EnvironmentType::OpenOcean);


### PR DESCRIPTION
## Summary
- add `GameSystems` helper to own game systems
- store systems in `GameSystems` instead of an `unordered_map`
- update PlayState initialization to use `GameSystems`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_6861694e4c9c833388ee422e040a80d5