### PR TITLE
Introduce SpawnSystem for hazard and power-up creation

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -12,6 +12,7 @@
 #include "ScoreSystem.h"
 #include "HUDSystem.h"
 #include "ParticleSystem.h"
+#include "SpawnSystem.h"
 #include "InputHandler.h"
 #include "PowerUp.h"
 #include "ExtendedPowerUps.h"
@@ -99,10 +100,7 @@ namespace FishGame
 
         // ==================== Helper Functions ====================
 
-        // Spawning helpers
-        void spawnRandomHazard();
-        void spawnRandomPowerUp();
-        sf::Vector2f generateRandomPosition();
+        // Spawning is handled by SpawnSystem
 
         // Effect helpers
         void createParticleEffect(const sf::Vector2f& position, const sf::Color& color,
@@ -211,9 +209,7 @@ namespace FishGame
         std::mt19937 m_randomEngine;
         std::uniform_real_distribution<float> m_angleDist;
         std::uniform_real_distribution<float> m_speedDist;
-        std::uniform_real_distribution<float> m_positionDist;
-        std::uniform_int_distribution<int> m_hazardTypeDist;
-        std::uniform_int_distribution<int> m_powerUpTypeDist;
+        std::unique_ptr<SpawnSystem> m_spawnSystem;
 
         bool m_initialized;
 

--- a/include/Systems/SpawnSystem.h
+++ b/include/Systems/SpawnSystem.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <memory>
+#include <random>
+#include <SFML/System.hpp>
+
+#include "Hazard.h"
+#include "PowerUp.h"
+#include "ExtendedPowerUps.h"
+
+namespace FishGame
+{
+    class SpriteManager;
+
+    class SpawnSystem
+    {
+    public:
+        SpawnSystem(SpriteManager& sprites, std::mt19937& rng, int& currentLevel, const sf::Font& font);
+
+        std::unique_ptr<Hazard> spawnRandomHazard();
+        std::unique_ptr<PowerUp> spawnRandomPowerUp();
+
+    private:
+        sf::Vector2f generateRandomPosition();
+
+        SpriteManager& m_spriteManager;
+        std::mt19937& m_randomEngine;
+        int& m_currentLevel;
+        const sf::Font& m_font;
+
+        std::uniform_real_distribution<float> m_xDist;
+        std::uniform_real_distribution<float> m_yDist;
+        std::uniform_int_distribution<int> m_hazardTypeDist;
+        std::uniform_int_distribution<int> m_powerUpTypeDist;
+    };
+}
+

--- a/src/Systems/SpawnSystem.cpp
+++ b/src/Systems/SpawnSystem.cpp
@@ -1,0 +1,94 @@
+#include "SpawnSystem.h"
+#include "SpriteManager.h"
+#include "GameConstants.h"
+
+namespace FishGame
+{
+    SpawnSystem::SpawnSystem(SpriteManager& sprites, std::mt19937& rng, int& currentLevel, const sf::Font& font)
+        : m_spriteManager(sprites)
+        , m_randomEngine(rng)
+        , m_currentLevel(currentLevel)
+        , m_font(font)
+        , m_xDist(Constants::SAFE_SPAWN_PADDING,
+            Constants::WINDOW_WIDTH - Constants::SAFE_SPAWN_PADDING)
+        , m_yDist(Constants::SAFE_SPAWN_PADDING,
+            Constants::WINDOW_HEIGHT - Constants::SAFE_SPAWN_PADDING)
+        , m_hazardTypeDist(0, 1)
+        , m_powerUpTypeDist(0, 2)
+    {
+    }
+
+    std::unique_ptr<Hazard> SpawnSystem::spawnRandomHazard()
+    {
+        std::unique_ptr<Hazard> hazard;
+
+        switch (m_hazardTypeDist(m_randomEngine))
+        {
+        case 0:
+            if (m_currentLevel >= 6)
+            {
+                hazard = std::make_unique<Bomb>();
+                static_cast<Bomb*>(hazard.get())->initializeSprite(m_spriteManager);
+            }
+            break;
+        case 1:
+            if (m_currentLevel >= 4)
+            {
+                hazard = std::make_unique<Jellyfish>();
+                static_cast<Jellyfish*>(hazard.get())->initializeSprite(m_spriteManager);
+                hazard->setVelocity(0.0f, 20.0f);
+            }
+            break;
+        }
+
+        if (hazard)
+        {
+            hazard->setPosition(generateRandomPosition());
+        }
+
+        return hazard;
+    }
+
+    std::unique_ptr<PowerUp> SpawnSystem::spawnRandomPowerUp()
+    {
+        std::unique_ptr<PowerUp> powerUp;
+
+        int type = m_powerUpTypeDist(m_randomEngine);
+        if (m_currentLevel < 2 && (type == 0 || type == 2))
+            type = 1;
+
+        switch (type)
+        {
+        case 0:
+            powerUp = std::make_unique<FreezePowerUp>();
+            if (auto* freeze = dynamic_cast<FreezePowerUp*>(powerUp.get()))
+                freeze->setFont(m_font);
+            break;
+        case 1:
+            powerUp = std::make_unique<ExtraLifePowerUp>();
+            if (auto* life = dynamic_cast<ExtraLifePowerUp*>(powerUp.get()))
+                life->initializeSprite(m_spriteManager);
+            break;
+        case 2:
+            powerUp = std::make_unique<SpeedBoostPowerUp>();
+            if (auto* speed = dynamic_cast<SpeedBoostPowerUp*>(powerUp.get()))
+                speed->initializeSprite(m_spriteManager);
+            break;
+        }
+
+        if (powerUp)
+        {
+            sf::Vector2f pos = generateRandomPosition();
+            powerUp->setPosition(pos);
+            powerUp->m_baseY = pos.y;
+        }
+
+        return powerUp;
+    }
+
+    sf::Vector2f SpawnSystem::generateRandomPosition()
+    {
+        return sf::Vector2f(m_xDist(m_randomEngine), m_yDist(m_randomEngine));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new `SpawnSystem` to handle spawning of hazards and power-ups
- update `PlayState` to delegate spawning through `SpawnSystem`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68616990efd883339208010e5abf1704