### PR TITLE
Introduce SpawnTimer utility

### DIFF
--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -20,6 +20,7 @@
 #include "BonusStageState.h"
 #include "GameConstants.h"
 #include "StateUtils.h"
+#include "SpawnTimer.h"
 #include <vector>
 #include <functional>
 #include <random>
@@ -110,7 +111,6 @@ namespace FishGame
         void applyEnvironmentalForces(sf::Time deltaTime);
 
         // State helpers
-        bool shouldSpawnSpecialEntity(sf::Time& timer, float interval);
         void updateEffectTimers(sf::Time deltaTime);
 
         // ==================== Core Methods ====================
@@ -188,8 +188,8 @@ namespace FishGame
         sf::Time m_controlReverseTimer;
         sf::Time m_freezeTimer;
         sf::Time m_stunTimer;
-        sf::Time m_hazardSpawnTimer;
-        sf::Time m_extendedPowerUpSpawnTimer;
+        SpawnTimer<sf::Time> m_hazardSpawnTimer;
+        SpawnTimer<sf::Time> m_extendedPowerUpSpawnTimer;
         InputHandler m_inputHandler;
 
         // Bonus stage tracking

--- a/include/Utils/SpawnTimer.h
+++ b/include/Utils/SpawnTimer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <type_traits>
+
+namespace FishGame
+{
+    // Generic timer for controlling spawn intervals
+    template <typename TimeType>
+    class SpawnTimer
+    {
+    public:
+        explicit SpawnTimer(TimeType interval = TimeType{})
+            : m_interval(interval), m_elapsed(TimeType{}) {}
+
+        // Update elapsed time and return true if the interval has elapsed
+        bool update(TimeType delta)
+        {
+            m_elapsed += delta;
+            if (m_elapsed >= m_interval && m_interval > TimeType{})
+            {
+                m_elapsed -= m_interval;
+                return true;
+            }
+            return false;
+        }
+
+        void reset(TimeType newElapsed = TimeType{}) { m_elapsed = newElapsed; }
+        void setInterval(TimeType interval) { m_interval = interval; }
+        TimeType getInterval() const { return m_interval; }
+
+    private:
+        TimeType m_interval;
+        TimeType m_elapsed;
+    };
+}

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -41,8 +41,8 @@ namespace FishGame
         , m_controlReverseTimer(sf::Time::Zero)
         , m_freezeTimer(sf::Time::Zero)
         , m_stunTimer(sf::Time::Zero)
-        , m_hazardSpawnTimer(sf::Time::Zero)
-        , m_extendedPowerUpSpawnTimer(sf::Time::Zero)
+        , m_hazardSpawnTimer(sf::seconds(m_hazardSpawnInterval))
+        , m_extendedPowerUpSpawnTimer(sf::seconds(m_extendedPowerUpInterval))
         , m_bonusStageTriggered(false)
         , m_returningFromBonusStage(false)
         , m_savedLevel(1)
@@ -312,12 +312,12 @@ namespace FishGame
             std::move(spawnedFish.begin(), spawnedFish.end(), std::back_inserter(m_entities));
             spawnedFish.clear();
 
-            if (shouldSpawnSpecialEntity(m_hazardSpawnTimer, m_hazardSpawnInterval))
+            if (m_hazardSpawnTimer.update(deltaTime))
             {
                 spawnRandomHazard();
             }
 
-            if (shouldSpawnSpecialEntity(m_extendedPowerUpSpawnTimer, m_extendedPowerUpInterval))
+            if (m_extendedPowerUpSpawnTimer.update(deltaTime))
             {
                 spawnRandomPowerUp();
             }
@@ -461,16 +461,6 @@ namespace FishGame
             });
     }
 
-    bool PlayState::shouldSpawnSpecialEntity(sf::Time& timer, float interval)
-    {
-        timer += sf::seconds(1.0f / 60.0f);
-        if (timer.asSeconds() >= interval)
-        {
-            timer = sf::Time::Zero;
-            return true;
-        }
-        return false;
-    }
 
     void PlayState::spawnRandomHazard()
     {


### PR DESCRIPTION
## Summary
- add generic `SpawnTimer` template in `Utils`
- replace hazard and power‑up timers with `SpawnTimer`
- update spawn logic to use the new timers
- remove obsolete helper

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `./build/oop2_project --help` *(fails: no X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_68616978abb88333adb2dfa66c2db0f2