### PR TITLE
Refactor sprite init duplication

### DIFF
--- a/include/Entities/Entity.h
+++ b/include/Entities/Entity.h
@@ -9,6 +9,7 @@ namespace FishGame
     // Forward declarations
     template<typename T> class SpriteComponent;
     enum class TextureID;
+    class SpriteManager;
 
     // Entity types for identification
     enum class EntityType
@@ -67,6 +68,9 @@ namespace FishGame
         void setSpriteComponent(std::unique_ptr<SpriteComponent<Entity>> sprite);
         SpriteComponent<Entity>* getSpriteComponent();
         const SpriteComponent<Entity>* getSpriteComponent() const;
+
+        // Helper to create a default sprite for this entity
+        void setupSprite(SpriteManager& spriteManager, TextureID textureId);
 
         // Visual mode
         enum class RenderMode { Circle, Sprite };

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -90,15 +90,7 @@ namespace FishGame
 
     void Starfish::initializeSprite(SpriteManager& spriteManager)
     {
-        auto sprite = spriteManager.createSpriteComponent(
-            static_cast<Entity*>(this), TextureID::Starfish);
-        if (sprite)
-        {
-            auto config = spriteManager.getSpriteConfig<Entity>(TextureID::Starfish);
-            sprite->configure(config);
-            setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
-        }
+        setupSprite(spriteManager, TextureID::Starfish);
     }
 
     void Starfish::update(sf::Time deltaTime)

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1,5 +1,6 @@
 #include "Entity.h"
 #include "SpriteComponent.h"
+#include "SpriteManager.h"
 
 namespace FishGame
 {
@@ -25,5 +26,18 @@ namespace FishGame
     void Entity::updatePosition(sf::Time deltaTime) noexcept
     {
         m_position += m_velocity * deltaTime.asSeconds();
+    }
+
+    void Entity::setupSprite(SpriteManager& spriteManager, TextureID textureId)
+    {
+        auto sprite = spriteManager.createSpriteComponent(
+            static_cast<Entity*>(this), textureId);
+        if (sprite)
+        {
+            auto config = spriteManager.getSpriteConfig<Entity>(textureId);
+            sprite->configure(config);
+            setSpriteComponent(std::move(sprite));
+            setRenderMode(RenderMode::Sprite);
+        }
     }
 }

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -155,15 +155,7 @@ namespace FishGame
 
     void ExtraLifePowerUp::initializeSprite(SpriteManager& spriteManager)
     {
-        auto sprite = spriteManager.createSpriteComponent(
-            static_cast<Entity*>(this), TextureID::PowerUpExtraLife);
-        if (sprite)
-        {
-            auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PowerUpExtraLife);
-            sprite->configure(config);
-            setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
-        }
+        setupSprite(spriteManager, TextureID::PowerUpExtraLife);
     }
 
     // SpeedBoostPowerUp implementation
@@ -254,15 +246,7 @@ namespace FishGame
 
     void SpeedBoostPowerUp::initializeSprite(SpriteManager& spriteManager)
     {
-        auto sprite = spriteManager.createSpriteComponent(
-            static_cast<Entity*>(this), TextureID::PowerUpSpeedBoost);
-        if (sprite)
-        {
-            auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PowerUpSpeedBoost);
-            sprite->configure(config);
-            setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
-        }
+        setupSprite(spriteManager, TextureID::PowerUpSpeedBoost);
     }
 
     // AddTimePowerUp implementation
@@ -299,14 +283,6 @@ namespace FishGame
 
     void AddTimePowerUp::initializeSprite(SpriteManager& spriteManager)
     {
-        auto sprite = spriteManager.createSpriteComponent(
-            static_cast<Entity*>(this), TextureID::PowerUpAddTime);
-        if (sprite)
-        {
-            auto config = spriteManager.getSpriteConfig<Entity>(TextureID::PowerUpAddTime);
-            sprite->configure(config);
-            setSpriteComponent(std::move(sprite));
-            setRenderMode(RenderMode::Sprite);
-        }
+        setupSprite(spriteManager, TextureID::PowerUpAddTime);
     }
 }


### PR DESCRIPTION
## Summary
- add `setupSprite` helper in `Entity`
- replace duplicated sprite setup code in bonus and power-up classes

## Testing
- `cmake -B build` *(fails: missing SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68618415080c833384122d779a1a0509