### PR TITLE
Add volume controls and back button to options

### DIFF
--- a/include/Core/MusicPlayer.h
+++ b/include/Core/MusicPlayer.h
@@ -1,50 +1,51 @@
 #pragma once
 
 #include <SFML/Audio.hpp>
-#include <unordered_map>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 namespace FishGame {
 
 enum class MusicID {
-    MenuTheme,
-    InGame1,
-    InGame2,
-    InGame3,
-    BonusStage,
-    InstructionsHelp,
-    ScoreSummary,
-    StageCleared,
-    PlayerDies
+  MenuTheme,
+  InGame1,
+  InGame2,
+  InGame3,
+  BonusStage,
+  InstructionsHelp,
+  ScoreSummary,
+  StageCleared,
+  PlayerDies
 };
 
 class MusicPlayer {
 public:
-    MusicPlayer();
+  MusicPlayer();
 
-    void play(MusicID theme, bool loop = true);
-    void stop();
-    void setVolume(float volume);
+  void play(MusicID theme, bool loop = true);
+  void stop();
+  void setVolume(float volume);
+  float getVolume() const { return m_volume; }
 
-    static constexpr float FadeDuration = 0.5f; ///< seconds
+  static constexpr float FadeDuration = 0.5f; ///< seconds
 
 private:
-    using MusicPtr = std::unique_ptr<sf::Music>;
+  using MusicPtr = std::unique_ptr<sf::Music>;
 
-    /// Pre-loaded music tracks for fast playback
-    std::unordered_map<MusicID, MusicPtr> m_musicTracks;
+  /// Pre-loaded music tracks for fast playback
+  std::unordered_map<MusicID, MusicPtr> m_musicTracks;
 
-    /// Mapping from music ID to file name
-    std::unordered_map<MusicID, std::string> m_filenames;
+  /// Mapping from music ID to file name
+  std::unordered_map<MusicID, std::string> m_filenames;
 
-    /// Currently playing music (non-owning pointer)
-    sf::Music* m_current;
+  /// Currently playing music (non-owning pointer)
+  sf::Music *m_current;
 
-    /// Background cross fade thread
-    std::jthread m_fadeThread;
+  /// Background cross fade thread
+  std::jthread m_fadeThread;
 
-    float m_volume;
+  float m_volume;
 };
 
-}
+} // namespace FishGame

--- a/include/Core/SoundPlayer.h
+++ b/include/Core/SoundPlayer.h
@@ -1,52 +1,52 @@
 #pragma once
 
 #include <SFML/Audio.hpp>
-#include <unordered_map>
-#include <vector>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace FishGame {
 
 enum class SoundEffectID {
-    Bite1,
-    Bite2,
-    Bite3,
-    Bite4,
-    FreezePowerup,
-    LifePowerup,
-    MineExplode,
-    MouseDown,
-    MouseOver,
-    OysterPearl,
-    PlayerGrow,
-    PlayerPoison,
-    PlayerSpawn,
-    PlayerStunned,
-    PufferBounce,
-    SpeedEnd,
-    SpeedStart,
-    StageIntro,
-    StarPickup,
-    FeedingFrenzy,
-    SuperFrenzy
+  Bite1,
+  Bite2,
+  Bite3,
+  Bite4,
+  FreezePowerup,
+  LifePowerup,
+  MineExplode,
+  MouseDown,
+  MouseOver,
+  OysterPearl,
+  PlayerGrow,
+  PlayerPoison,
+  PlayerSpawn,
+  PlayerStunned,
+  PufferBounce,
+  SpeedEnd,
+  SpeedStart,
+  StageIntro,
+  StarPickup,
+  FeedingFrenzy,
+  SuperFrenzy
 };
 
 class SoundPlayer {
 public:
-    SoundPlayer();
+  SoundPlayer();
 
-    void play(SoundEffectID effect);
-    void setVolume(float volume);
+  void play(SoundEffectID effect);
+  void setVolume(float volume);
+  float getVolume() const { return m_volume; }
 
 private:
-    using BufferPtr = std::unique_ptr<sf::SoundBuffer>;
+  using BufferPtr = std::unique_ptr<sf::SoundBuffer>;
 
-    std::unordered_map<SoundEffectID, BufferPtr> m_soundBuffers;
-    std::unordered_map<SoundEffectID, std::string> m_filenames;
-    std::vector<sf::Sound> m_sounds;
-    float m_volume;
+  std::unordered_map<SoundEffectID, BufferPtr> m_soundBuffers;
+  std::unordered_map<SoundEffectID, std::string> m_filenames;
+  std::vector<sf::Sound> m_sounds;
+  float m_volume;
 };
 
-}
-
+} // namespace FishGame

--- a/include/States/GameOptionsState.h
+++ b/include/States/GameOptionsState.h
@@ -1,27 +1,34 @@
 #pragma once
 
-#include "State.h"
 #include "GameConstants.h"
+#include "State.h"
 
-namespace FishGame
-{
-    class GameOptionsState;
-    template<> struct is_state<GameOptionsState> : std::true_type {};
+namespace FishGame {
+class GameOptionsState;
+template <> struct is_state<GameOptionsState> : std::true_type {};
 
-    class GameOptionsState : public State
-    {
-    public:
-        explicit GameOptionsState(Game& game);
-        ~GameOptionsState() override = default;
+class GameOptionsState : public State {
+public:
+  explicit GameOptionsState(Game &game);
+  ~GameOptionsState() override = default;
 
-        void handleEvent(const sf::Event& event) override;
-        bool update(sf::Time deltaTime) override;
-        void render() override;
-        void onActivate() override;
+  void handleEvent(const sf::Event &event) override;
+  bool update(sf::Time deltaTime) override;
+  void render() override;
+  void onActivate() override;
+  void updateVolumeTexts();
 
-    private:
-        sf::Text m_titleText;
-        sf::Text m_instructionText;
-        sf::RectangleShape m_background;
-    };
-}
+private:
+  sf::Text m_titleText;
+  sf::Text m_instructionText;
+  sf::Text m_musicVolumeText;
+  sf::Text m_soundVolumeText;
+  sf::Sprite m_overlaySprite;
+  sf::Sprite m_backButtonSprite;
+  sf::Text m_backText;
+  sf::RectangleShape m_background;
+  bool m_buttonHovered{false};
+  float m_musicVolume{100.f};
+  float m_soundVolume{100.f};
+};
+} // namespace FishGame

--- a/src/States/GameOptionsState.cpp
+++ b/src/States/GameOptionsState.cpp
@@ -1,62 +1,160 @@
 #include "GameOptionsState.h"
 #include "Game.h"
 
-namespace FishGame
-{
-    GameOptionsState::GameOptionsState(Game& game)
-        : State(game)
-        , m_titleText()
-        , m_instructionText()
-        , m_background()
-    {
-    }
+namespace FishGame {
+GameOptionsState::GameOptionsState(Game &game)
+    : State(game), m_titleText(), m_instructionText(), m_musicVolumeText(),
+      m_soundVolumeText(), m_overlaySprite(), m_backButtonSprite(),
+      m_backText(), m_background() {}
 
-    void GameOptionsState::onActivate()
-    {
-        auto& window = getGame().getWindow();
-        auto& font = getGame().getFonts().get(Fonts::Main);
+void GameOptionsState::onActivate() {
+  auto &window = getGame().getWindow();
+  auto &font = getGame().getFonts().get(Fonts::Main);
+  auto &manager = getGame().getSpriteManager();
 
-        m_background.setSize(sf::Vector2f(window.getSize()));
-        m_background.setFillColor(Constants::OVERLAY_COLOR);
+  m_musicVolume = getGame().getMusicPlayer().getVolume();
+  m_soundVolume = getGame().getSoundPlayer().getVolume();
 
-        m_titleText.setFont(font);
-        m_titleText.setString("OPTIONS");
-        m_titleText.setCharacterSize(72);
-        m_titleText.setFillColor(sf::Color::White);
-        auto bounds = m_titleText.getLocalBounds();
-        m_titleText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        float winWidth = static_cast<float>(window.getSize().x);
-        float winHeight = static_cast<float>(window.getSize().y);
-        m_titleText.setPosition(winWidth / 2.f, winHeight / 2.f - 40.f);
+  m_background.setSize(sf::Vector2f(window.getSize()));
+  m_background.setFillColor(Constants::OVERLAY_COLOR);
 
-        m_instructionText.setFont(font);
-        m_instructionText.setString("Press Esc to return");
-        m_instructionText.setCharacterSize(36);
-        m_instructionText.setFillColor(sf::Color::White);
-        bounds = m_instructionText.getLocalBounds();
-        m_instructionText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        m_instructionText.setPosition(winWidth / 2.f, winHeight / 2.f + 40.f);
-    }
+  m_overlaySprite.setTexture(manager.getTexture(TextureID::StageIntro));
+  auto size = m_overlaySprite.getTexture()->getSize();
+  m_overlaySprite.setScale(static_cast<float>(window.getSize().x) / size.x,
+                           static_cast<float>(window.getSize().y) / size.y);
 
-    void GameOptionsState::handleEvent(const sf::Event& event)
-    {
-        if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape)
-        {
-            deferAction([this]() { requestStackPop(); });
-        }
-    }
+  m_titleText.setFont(font);
+  m_titleText.setString("OPTIONS");
+  m_titleText.setCharacterSize(72);
+  m_titleText.setFillColor(sf::Color::White);
+  auto bounds = m_titleText.getLocalBounds();
+  m_titleText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+  float winWidth = static_cast<float>(window.getSize().x);
+  float winHeight = static_cast<float>(window.getSize().y);
+  m_titleText.setPosition(winWidth / 2.f, 180.f);
 
-    bool GameOptionsState::update(sf::Time)
-    {
-        processDeferredActions();
-        return false;
-    }
+  m_instructionText.setFont(font);
+  m_instructionText.setString("Use Arrows to change volume");
+  m_instructionText.setCharacterSize(36);
+  m_instructionText.setFillColor(sf::Color::White);
+  bounds = m_instructionText.getLocalBounds();
+  m_instructionText.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+  m_instructionText.setPosition(winWidth / 2.f, winHeight / 2.f + 200.f);
 
-    void GameOptionsState::render()
-    {
-        auto& window = getGame().getWindow();
-        window.draw(m_background);
-        window.draw(m_titleText);
-        window.draw(m_instructionText);
-    }
+  m_musicVolumeText.setFont(font);
+  m_musicVolumeText.setCharacterSize(48);
+  m_musicVolumeText.setFillColor(sf::Color::White);
+
+  m_soundVolumeText.setFont(font);
+  m_soundVolumeText.setCharacterSize(48);
+  m_soundVolumeText.setFillColor(sf::Color::White);
+
+  m_backButtonSprite.setTexture(manager.getTexture(TextureID::Button));
+  auto b = m_backButtonSprite.getLocalBounds();
+  m_backButtonSprite.setOrigin(b.width / 2.f, b.height / 2.f);
+  m_backButtonSprite.setScale(Constants::MENU_BUTTON_SCALE,
+                              Constants::MENU_BUTTON_SCALE);
+  m_backButtonSprite.setPosition(winWidth / 2.f, winHeight - 150.f);
+
+  m_backText.setFont(font);
+  m_backText.setString("BACK");
+  m_backText.setCharacterSize(36);
+  auto bb = m_backText.getLocalBounds();
+  m_backText.setOrigin(bb.width / 2.f, bb.height / 2.f + 10.f);
+  m_backText.setPosition(m_backButtonSprite.getPosition());
+  m_backText.setFillColor(sf::Color(0, 16, 112));
+
+  m_buttonHovered = false;
+
+  updateVolumeTexts();
 }
+
+void GameOptionsState::updateVolumeTexts() {
+  auto &window = getGame().getWindow();
+  m_musicVolumeText.setString("Music Volume: " +
+                              std::to_string(static_cast<int>(m_musicVolume)));
+  m_soundVolumeText.setString("Sound Volume: " +
+                              std::to_string(static_cast<int>(m_soundVolume)));
+
+  auto mb = m_musicVolumeText.getLocalBounds();
+  m_musicVolumeText.setOrigin(mb.width / 2.f, mb.height / 2.f);
+  m_musicVolumeText.setPosition(static_cast<float>(window.getSize().x) / 2.f,
+                                static_cast<float>(window.getSize().y) / 2.f -
+                                    40.f);
+
+  auto sb = m_soundVolumeText.getLocalBounds();
+  m_soundVolumeText.setOrigin(sb.width / 2.f, sb.height / 2.f);
+  m_soundVolumeText.setPosition(static_cast<float>(window.getSize().x) / 2.f,
+                                static_cast<float>(window.getSize().y) / 2.f +
+                                    40.f);
+}
+
+void GameOptionsState::handleEvent(const sf::Event &event) {
+  auto &music = getGame().getMusicPlayer();
+  auto &sounds = getGame().getSoundPlayer();
+
+  if (event.type == sf::Event::KeyPressed) {
+    switch (event.key.code) {
+    case sf::Keyboard::Escape:
+      deferAction([this]() { requestStackPop(); });
+      break;
+    case sf::Keyboard::Up:
+      m_musicVolume = std::min(100.f, m_musicVolume + 5.f);
+      music.setVolume(m_musicVolume);
+      updateVolumeTexts();
+      break;
+    case sf::Keyboard::Down:
+      m_musicVolume = std::max(0.f, m_musicVolume - 5.f);
+      music.setVolume(m_musicVolume);
+      updateVolumeTexts();
+      break;
+    case sf::Keyboard::Right:
+      m_soundVolume = std::min(100.f, m_soundVolume + 5.f);
+      sounds.setVolume(m_soundVolume);
+      updateVolumeTexts();
+      break;
+    case sf::Keyboard::Left:
+      m_soundVolume = std::max(0.f, m_soundVolume - 5.f);
+      sounds.setVolume(m_soundVolume);
+      updateVolumeTexts();
+      break;
+    default:
+      break;
+    }
+  } else if (event.type == sf::Event::MouseMoved) {
+    sf::Vector2f pos(static_cast<float>(event.mouseMove.x),
+                     static_cast<float>(event.mouseMove.y));
+    bool hover = m_backButtonSprite.getGlobalBounds().contains(pos);
+    if (hover != m_buttonHovered) {
+      m_buttonHovered = hover;
+      auto &manager = getGame().getSpriteManager();
+      m_backButtonSprite.setTexture(manager.getTexture(
+          hover ? TextureID::ButtonHover : TextureID::Button));
+    }
+  } else if (event.type == sf::Event::MouseButtonPressed &&
+             event.mouseButton.button == sf::Mouse::Left) {
+    sf::Vector2f pos(static_cast<float>(event.mouseButton.x),
+                     static_cast<float>(event.mouseButton.y));
+    if (m_backButtonSprite.getGlobalBounds().contains(pos)) {
+      deferAction([this]() { requestStackPop(); });
+    }
+  }
+}
+
+bool GameOptionsState::update(sf::Time) {
+  processDeferredActions();
+  return false;
+}
+
+void GameOptionsState::render() {
+  auto &window = getGame().getWindow();
+  window.draw(m_background);
+  window.draw(m_overlaySprite);
+  window.draw(m_titleText);
+  window.draw(m_musicVolumeText);
+  window.draw(m_soundVolumeText);
+  window.draw(m_instructionText);
+  window.draw(m_backButtonSprite);
+  window.draw(m_backText);
+}
+} // namespace FishGame


### PR DESCRIPTION
## Summary
- expose `getVolume` helpers for music and sound
- add back button and volume controls to `GameOptionsState`
- show stage intro overlay in options screen

## Testing
- `cmake -S . -B build` *(fails: FindSFML.cmake not found)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6861964f35b08333b517e322a803aae5