### PR TITLE
Add fish info pages to options

### DIFF
--- a/include/States/GameOptionsState.h
+++ b/include/States/GameOptionsState.h
@@ -2,6 +2,7 @@
 
 #include "GameConstants.h"
 #include "State.h"
+#include <vector>
 
 namespace FishGame {
 class GameOptionsState;
@@ -26,11 +27,25 @@ private:
   sf::Text m_musicVolumeText;
   sf::Text m_soundVolumeText;
   sf::Sprite m_overlaySprite;
+  struct InfoItem {
+    sf::Sprite sprite;
+    sf::Text text;
+    TextureID tex{TextureID::SmallFish};
+  };
+
+  void setupInfoItems();
+  void updateCurrentInfo();
+
   sf::Sprite m_backButtonSprite;
+  sf::Sprite m_nextButtonSprite;
   sf::Text m_backText;
+  sf::Text m_nextText;
   sf::RectangleShape m_background;
-  bool m_buttonHovered{false};
+  bool m_backButtonHovered{false};
+  bool m_nextButtonHovered{false};
   float m_musicVolume{100.f};
   float m_soundVolume{100.f};
-};
+  std::vector<InfoItem> m_infoItems;
+  std::size_t m_currentIndex{0};
+}; 
 } // namespace FishGame


### PR DESCRIPTION
## Summary
- show fish and hazard info in Options state
- add NEXT button to navigate info pages

## Testing
- `cmake -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_686199d5f70c8333b4870954125d5517