### PR TITLE
Improve player acceleration for smoother start

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -37,7 +37,7 @@ namespace FishGame
             PowerUpManager* powerUpManager, ScoreSystem* scoreSystem);
 
         // Player-specific methods
-        void handleInput();
+        void handleInput(sf::Time deltaTime);
         sf::Vector2f getTargetPosition() const { return m_targetPosition; }
 
         // Sprite initialization

--- a/include/Entities/PlayerInput.h
+++ b/include/Entities/PlayerInput.h
@@ -13,7 +13,7 @@ namespace FishGame
     {
     public:
         explicit PlayerInput(Player& player);
-        void handleInput();
+        void handleInput(sf::Time deltaTime);
     private:
         Player& m_player;
     };

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -126,7 +126,7 @@ namespace FishGame
         }
 
         // Handle input
-        handleInput();
+        handleInput(deltaTime);
 
 
         // Limit maximum speed
@@ -209,10 +209,10 @@ namespace FishGame
         }
     }
 
-    void Player::handleInput()
+    void Player::handleInput(sf::Time deltaTime)
     {
         if (m_input)
-            m_input->handleInput();
+            m_input->handleInput(deltaTime);
     }
 
     sf::FloatRect Player::getBounds() const

--- a/src/Entities/PlayerInput.cpp
+++ b/src/Entities/PlayerInput.cpp
@@ -7,7 +7,7 @@ namespace FishGame {
 
 PlayerInput::PlayerInput(Player& player) : m_player(player) {}
 
-void PlayerInput::handleInput()
+void PlayerInput::handleInput(sf::Time deltaTime)
 {
     sf::Vector2f inputDirection(0.f, 0.f);
     bool keyboardUsed = false;
@@ -44,13 +44,27 @@ void PlayerInput::handleInput()
         if (length > 0.f)
         {
             inputDirection /= length;
-            float speed = Player::m_baseSpeed * (m_player.m_speedBoostTimer > sf::Time::Zero ? m_player.m_speedMultiplier : 1.f);
-            m_player.m_velocity = inputDirection * speed;
+            float maxSpeed = Player::m_baseSpeed * (m_player.m_speedBoostTimer > sf::Time::Zero ? m_player.m_speedMultiplier : 1.f);
+            sf::Vector2f desiredVelocity = inputDirection * maxSpeed;
+            sf::Vector2f diff = desiredVelocity - m_player.m_velocity;
+            float diffLength = std::sqrt(diff.x * diff.x + diff.y * diff.y);
+            float accelStep = Player::m_acceleration * deltaTime.asSeconds();
+            if (diffLength > accelStep)
+                diff = diff / diffLength * accelStep;
+            m_player.m_velocity += diff;
         }
     }
     else
     {
-        m_player.m_velocity *= 0.9f;
+        float speed = std::sqrt(m_player.m_velocity.x * m_player.m_velocity.x + m_player.m_velocity.y * m_player.m_velocity.y);
+        if (speed > 0.f)
+        {
+            float decelStep = Player::m_deceleration * deltaTime.asSeconds();
+            if (speed > decelStep)
+                m_player.m_velocity -= (m_player.m_velocity / speed) * decelStep;
+            else
+                m_player.m_velocity = sf::Vector2f(0.f, 0.f);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add deltaTime parameter for PlayerInput to apply acceleration
- update Player to pass deltaTime when handling input
- gradually accelerate and decelerate player velocity

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68630377552c8333bdafb5e3f092e592