### PR TITLE
Fix state registration comment

### DIFF
--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -192,10 +192,9 @@ namespace FishGame
                 return std::make_unique<BonusStageState>(*this, cfg.type, cfg.playerLevel);
             });
 
-        // TODO: Register additional states as they are implemented
+        // Register optional states
         registerState<GameOptionsState>(StateID::GameOptions);
         registerState<GameOverState>(StateID::GameOver);
-        // registerState<CreditsState>(StateID::Credits);
     }
 
 }


### PR DESCRIPTION
## Summary
- remove TODO comment from `registerStates`
- clean up unused placeholder line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865788998348333b209b90e213a9b2c