### PR TITLE
Fix compile errors and include missing headers

### DIFF
--- a/include/Entities/Angelfish.h
+++ b/include/Entities/Angelfish.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdvancedFish.h"
+#include "SpriteManager.h"
 #include <vector>
 #include <SFML/Graphics/CircleShape.hpp>
 

--- a/include/Entities/Barracuda.h
+++ b/include/Entities/Barracuda.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdvancedFish.h"
+#include "SpriteManager.h"
 #include "Animator.h"
 
 namespace FishGame {

--- a/include/Entities/PoisonFish.h
+++ b/include/Entities/PoisonFish.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdvancedFish.h"
+#include "SpriteManager.h"
 #include <vector>
 #include <SFML/Graphics/CircleShape.hpp>
 

--- a/include/Entities/Pufferfish.h
+++ b/include/Entities/Pufferfish.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdvancedFish.h"
+#include "SpriteManager.h"
 #include <vector>
 #include <SFML/Graphics/CircleShape.hpp>
 

--- a/src/Entities/Angelfish.cpp
+++ b/src/Entities/Angelfish.cpp
@@ -4,6 +4,7 @@
 #include "Player.h"
 #include "SpriteManager.h"
 #include "Animator.h"
+#include "Pufferfish.h"
 #include <random>
 #include <algorithm>
 #include <cmath>
@@ -306,6 +307,5 @@ namespace FishGame
             m_velocity = newVelocity;
         }
     }
-}
 }
 

--- a/src/Systems/CollisionSystem.cpp
+++ b/src/Systems/CollisionSystem.cpp
@@ -1,6 +1,9 @@
 #include "CollisionSystem.h"
 #include "GameConstants.h"
 #include "StateUtils.h"
+#include "Pufferfish.h"
+#include "Angelfish.h"
+#include "PoisonFish.h"
 #include <algorithm>
 
 namespace FishGame


### PR DESCRIPTION
## Summary
- include `SpriteManager.h` in various fish headers
- include `Pufferfish.h` in `Angelfish.cpp`
- include fish headers in `CollisionSystem`
- remove stray brace from `Angelfish.cpp`

## Testing
- `cmake --build . -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_686580c4acac833392bf5cc95790afaf