### PR TITLE
Refactor to sprite-only entities

### DIFF
--- a/include/Entities/Angelfish.h
+++ b/include/Entities/Angelfish.h
@@ -3,7 +3,6 @@
 #include "AdvancedFish.h"
 #include "SpriteManager.h"
 #include <vector>
-#include <SFML/Graphics/CircleShape.hpp>
 
 namespace FishGame {
 
@@ -35,7 +34,6 @@ private:
 private:
     int m_bonusPoints;
     float m_colorShift;
-    std::vector<sf::CircleShape> m_fins;
     sf::Time m_directionChangeTimer;
 
     const Entity* m_currentThreat;

--- a/include/Entities/PoisonFish.h
+++ b/include/Entities/PoisonFish.h
@@ -3,7 +3,6 @@
 #include "AdvancedFish.h"
 #include "SpriteManager.h"
 #include <vector>
-#include <SFML/Graphics/CircleShape.hpp>
 
 namespace FishGame {
 
@@ -26,17 +25,12 @@ protected:
     void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
 private:
-    void updatePoisonBubbles(sf::Time /*deltaTime*/);
-
-private:
-    std::vector<sf::CircleShape> m_poisonBubbles;
     float m_wobbleAnimation;
     sf::Time m_poisonDuration;
     int m_poisonPoints;
 
     static constexpr float m_poisonEffectDuration = 5.0f;
     static constexpr int m_basePoisonPoints = -10;
-    static constexpr int m_bubbleCount = 6;
 };
 
 } // namespace FishGame

--- a/include/Entities/Pufferfish.h
+++ b/include/Entities/Pufferfish.h
@@ -3,7 +3,6 @@
 #include "AdvancedFish.h"
 #include "SpriteManager.h"
 #include <vector>
-#include <SFML/Graphics/CircleShape.hpp>
 
 namespace FishGame {
 
@@ -44,7 +43,6 @@ private:
     sf::Time m_stateTimer;
     float m_inflationLevel;
     float m_normalRadius;
-    std::vector<sf::CircleShape> m_spikes;
 
     static constexpr float m_pushDistance = 10.0f;
     static constexpr float m_pushForce = 500.0f;
@@ -53,7 +51,6 @@ private:
     static constexpr float m_inflationSpeed = 3.0f;
     static constexpr float m_deflationSpeed = 3.0f;
     static constexpr float m_inflatedRadiusMultiplier = 2.0f;
-    static constexpr int m_spikeCount = 8;
 
     bool m_isPuffing{ false };
     sf::Time m_puffTimer{ sf::Time::Zero };

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -41,12 +41,10 @@ namespace FishGame
     void Game::run()
     {
         sf::Clock clock;
-        sf::Time timeSinceLastUpdate = sf::Time::Zero;
 
         while (m_window.isOpen())
         {
             const sf::Time deltaTime = clock.restart();
-            timeSinceLastUpdate += deltaTime;
 
             // Update performance metrics
             m_metrics.accumulatedTime += deltaTime;
@@ -60,20 +58,11 @@ namespace FishGame
                 m_metrics.accumulatedTime = sf::Time::Zero;
             }
 
-            // Fixed timestep with interpolation
-            while (timeSinceLastUpdate > m_timePerFrame)
-            {
-                timeSinceLastUpdate -= m_timePerFrame;
+            processInput();
+            update(deltaTime);
 
-                processInput();
-                update(m_timePerFrame);
-
-                // Check if we need to close
-                if (m_stateManager.empty())
-                {
-                    m_window.close();
-                }
-            }
+            if (m_stateManager.empty())
+                m_window.close();
 
             render();
         }

--- a/src/Entities/Angelfish.cpp
+++ b/src/Entities/Angelfish.cpp
@@ -8,8 +8,6 @@
 #include <random>
 #include <algorithm>
 #include <cmath>
-#include <iterator>
-#include <ranges>
 #include <execution>
 
 namespace FishGame
@@ -24,14 +22,6 @@ namespace FishGame
         , m_isEvading(false)
         , m_evasionTimer(sf::Time::Zero)
     {
-        // Create decorative fins
-        m_fins.reserve(3);
-        std::generate_n(std::back_inserter(m_fins), 3, [] {
-            sf::CircleShape fin(10.0f, 3);
-            fin.setFillColor(sf::Color(255, 200, 100, 150));
-            fin.setOrigin(10.0f, 10.0f);
-            return fin;
-            });
     }
 
     void Angelfish::update(sf::Time deltaTime)
@@ -66,28 +56,7 @@ namespace FishGame
         // Update visual effects (continue even when frozen)
         m_colorShift += deltaTime.asSeconds() * (m_isFrozen ? 0.5f : 2.0f);
 
-        // Update fin positions with more dynamic movement
-        auto finIdx = std::views::iota(size_t{ 0 }, m_fins.size());
-        std::for_each(std::execution::unseq, finIdx.begin(), finIdx.end(),
-            [this](size_t i)
-            {
-                float finAngle = (m_colorShift + i * 120.0f) * 3.14159f / 180.0f;
-                float finRadius = 20.0f + (m_isEvading ? 10.0f * std::sin(m_colorShift * 5.0f) : 0.0f);
-
-                sf::Vector2f finPos(
-                    m_position.x + std::cos(finAngle) * finRadius,
-                    m_position.y + std::sin(finAngle) * finRadius);
-
-                m_fins[i].setPosition(finPos);
-                m_fins[i].setRotation(finAngle * Constants::RAD_TO_DEG);
-
-                // Pulse fins when evading (unless frozen)
-                if (m_isEvading && !m_isFrozen)
-                {
-                    float scale = 1.0f + 0.3f * std::sin(m_colorShift * 10.0f);
-                    m_fins[i].setScale(scale, scale);
-                }
-            });
+        // Fin animation removed
     }
 
     void Angelfish::updateAI(const std::vector<std::unique_ptr<Entity>>& entities,
@@ -271,13 +240,6 @@ namespace FishGame
 
     void Angelfish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        // Draw fins first
-        std::for_each(m_fins.begin(), m_fins.end(),
-            [&target, &states](const sf::CircleShape& fin)
-            {
-                target.draw(fin, states);
-            });
-
         Fish::draw(target, states);
     }
 

--- a/src/Entities/PoisonFish.cpp
+++ b/src/Entities/PoisonFish.cpp
@@ -4,19 +4,13 @@
 #include "Player.h"
 #include "SpriteManager.h"
 #include "Animator.h"
-#include <random>
-#include <algorithm>
 #include <cmath>
-#include <iterator>
-#include <ranges>
-#include <execution>
 
 namespace FishGame
 {
     // PoisonFish implementation
     PoisonFish::PoisonFish(int currentLevel)
         : AdvancedFish(FishSize::Small, 130.0f, currentLevel, MovementPattern::Sinusoidal)
-        , m_poisonBubbles()
         , m_wobbleAnimation(0.0f)
         , m_poisonDuration(sf::seconds(m_poisonEffectDuration))
         , m_poisonPoints(m_basePoisonPoints* currentLevel)
@@ -28,14 +22,6 @@ namespace FishGame
         m_amplitude = 15.0f;
         m_frequency = 3.0f;
 
-        // Create poison bubble effects - smaller bubbles for small fish
-        m_poisonBubbles.reserve(m_bubbleCount);
-        std::generate_n(std::back_inserter(m_poisonBubbles), m_bubbleCount, [] {
-            sf::CircleShape bubble(2.0f);
-            bubble.setFillColor(sf::Color(200, 100, 255, 150));
-            bubble.setOrigin(2.0f, 2.0f);
-            return bubble;
-            });
     }
 
     void PoisonFish::update(sf::Time deltaTime)
@@ -58,40 +44,10 @@ namespace FishGame
             m_wobbleAnimation += deltaTime.asSeconds() * 3.0f;
         }
 
-        // Update poison bubbles
-        updatePoisonBubbles(deltaTime);
-    }
-
-    void PoisonFish::updatePoisonBubbles(sf::Time /*deltaTime*/)
-    {
-        auto bubbleIdx = std::views::iota(size_t{ 0 }, m_poisonBubbles.size());
-        std::for_each(std::execution::unseq, bubbleIdx.begin(), bubbleIdx.end(),
-            [this](size_t i)
-            {
-                float angle = (60.0f * i + m_wobbleAnimation * 30.0f) * Constants::DEG_TO_RAD;
-                float radius = 18.0f + 3.0f * std::sin(m_wobbleAnimation + i);
-
-                sf::Vector2f bubblePos(
-                    m_position.x + std::cos(angle) * radius,
-                    m_position.y + std::sin(angle) * radius);
-
-                m_poisonBubbles[i].setPosition(bubblePos);
-
-                // Pulsing effect for bubbles
-                float scale = 1.0f + 0.2f * std::sin(m_wobbleAnimation * 2.0f + i);
-                m_poisonBubbles[i].setScale(scale, scale);
-            });
     }
 
     void PoisonFish::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
-        // Draw poison bubbles first
-        std::for_each(m_poisonBubbles.begin(), m_poisonBubbles.end(),
-            [&target, &states](const sf::CircleShape& bubble) {
-                target.draw(bubble, states);
-            });
-
-        // Draw the fish
         Fish::draw(target, states);
     }
 

--- a/src/Entities/Pufferfish.cpp
+++ b/src/Entities/Pufferfish.cpp
@@ -4,12 +4,8 @@
 #include "Player.h"
 #include "SpriteManager.h"
 #include "Animator.h"
-#include <random>
 #include <algorithm>
 #include <cmath>
-#include <iterator>
-#include <ranges>
-#include <execution>
 
 namespace FishGame
 {
@@ -25,14 +21,6 @@ namespace FishGame
     {
         m_radius = m_normalRadius;
 
-        // Create spikes
-        m_spikes.reserve(m_spikeCount);
-        std::generate_n(std::back_inserter(m_spikes), m_spikeCount, [] {
-            sf::CircleShape spike(3.0f, 3);  // Triangle
-            spike.setFillColor(sf::Color(150, 100, 50));
-            spike.setOrigin(3.0f, 3.0f);
-            return spike;
-            });
     }
 
     void Pufferfish::initializeSprite(SpriteManager& spriteManager)
@@ -60,20 +48,7 @@ namespace FishGame
             updateMovement(deltaTime);
 
             // Still update visual elements but not state transitions
-            auto spikeIdx = std::views::iota(size_t{ 0 }, m_spikes.size());
-            std::for_each(std::execution::unseq, spikeIdx.begin(), spikeIdx.end(),
-                [this](size_t i)
-                {
-                    float angle = (360.0f / m_spikeCount) * i * Constants::DEG_TO_RAD;
-                    float spikeRadius = m_radius + (m_inflationLevel * 10.0f);
-
-                    sf::Vector2f spikePos(
-                        m_position.x + std::cos(angle) * spikeRadius,
-                        m_position.y + std::sin(angle) * spikeRadius);
-
-                    m_spikes[i].setPosition(spikePos);
-                    m_spikes[i].setRotation(angle * Constants::RAD_TO_DEG);
-                });
+            // Old spike animation removed
             return;
         }
 
@@ -106,21 +81,7 @@ namespace FishGame
             }
         }
 
-        // Update spike positions
-        auto spikeIdx2 = std::views::iota(size_t{ 0 }, m_spikes.size());
-        std::for_each(std::execution::unseq, spikeIdx2.begin(), spikeIdx2.end(),
-            [this](size_t i)
-            {
-                float angle = (360.0f / m_spikeCount) * i * Constants::DEG_TO_RAD;
-                float spikeRadius = m_radius + (m_inflationLevel * 10.0f);
-
-                sf::Vector2f spikePos(
-                    m_position.x + std::cos(angle) * spikeRadius,
-                    m_position.y + std::sin(angle) * spikeRadius);
-
-                m_spikes[i].setPosition(spikePos);
-                m_spikes[i].setRotation(angle * Constants::RAD_TO_DEG);
-            });
+        // Spike visuals removed
     }
 
     bool Pufferfish::canEat(const Entity& other) const
@@ -171,15 +132,7 @@ namespace FishGame
     {
         Fish::draw(target, states);
 
-        // Draw spikes when inflating
-        if (m_inflationLevel > 0.2f)
-        {
-            std::for_each(m_spikes.begin(), m_spikes.end(),
-                [&target, &states](const sf::CircleShape& spike)
-                {
-                    target.draw(spike, states);
-                });
-        }
+        // Spike drawing removed
     }
 
 


### PR DESCRIPTION
## Summary
- remove obsolete CircleShape fields from fish entities
- drop circle-based effects from Angelfish, Pufferfish and PoisonFish
- update main game loop to use variable timestep

## Testing
- `cmake ..`
- `cmake --build .`
- `./oop2_project --version` *(fails: Failed to open X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_68658b936c048333a9040ecaf77b0224