### PR TITLE
Add high scores and name entry

### DIFF
--- a/include/Core/State.h
+++ b/include/Core/State.h
@@ -15,12 +15,14 @@ namespace FishGame
     {
         None,
         Intro,
+        PlayerName,
         StageIntro,
         StageSummary,
         Menu,
         Play,
         GameOver,
-		GameOptions,
+        GameOptions,
+        HighScores,
         BonusStage
     };
 

--- a/include/Managers/SpriteManager.h
+++ b/include/Managers/SpriteManager.h
@@ -62,6 +62,8 @@ namespace FishGame
         , NewGameHover
         , GameOptions
         , GameOptionsHover
+        , HighScores
+        , HighScoresHover
         , Exit
         , ExitHover
         , Intro1

--- a/include/States/GameOverState.h
+++ b/include/States/GameOverState.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <vector>
 #include <array>
+#include <string>
 #include <algorithm>
 #include <numeric>
 #include <random>
@@ -22,6 +23,7 @@ namespace FishGame
     // Global game statistics (simple solution for passing data between states)
     struct GameStats
     {
+        std::string playerName;
         int finalScore = 0;
         int highScore = 0;
         int fishEaten = 0;

--- a/include/States/HighScoresState.h
+++ b/include/States/HighScoresState.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "State.h"
+#include "GameConstants.h"
+#include "Utils/HighScoreIO.h"
+#include <vector>
+
+namespace FishGame {
+class HighScoresState;
+template<> struct is_state<HighScoresState> : std::true_type {};
+
+class HighScoresState : public State {
+public:
+    explicit HighScoresState(Game& game);
+    ~HighScoresState() override = default;
+
+    void handleEvent(const sf::Event& event) override;
+    bool update(sf::Time dt) override;
+    void render() override;
+    void onActivate() override;
+
+private:
+    void loadScores();
+    std::vector<HighScoreEntry> m_scores;
+    sf::Text m_titleText;
+    std::vector<sf::Text> m_scoreTexts;
+    sf::Sprite m_backButton;
+    bool m_hover{false};
+};
+}

--- a/include/States/MenuState.h
+++ b/include/States/MenuState.h
@@ -34,6 +34,7 @@ namespace FishGame
         {
             NewGame = 0,
             GameOptions,
+            HighScores,
             Exit,
             Count
         };

--- a/include/States/PlayerNameState.h
+++ b/include/States/PlayerNameState.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "State.h"
+#include <string>
+
+namespace FishGame {
+class PlayerNameState;
+template<> struct is_state<PlayerNameState> : std::true_type {};
+
+class PlayerNameState : public State {
+public:
+    explicit PlayerNameState(Game& game);
+    ~PlayerNameState() override = default;
+
+    void handleEvent(const sf::Event& event) override;
+    bool update(sf::Time dt) override;
+    void render() override;
+    void onActivate() override;
+
+private:
+    std::string m_input;
+    sf::Text m_prompt;
+    sf::Text m_inputText;
+};
+}

--- a/include/Utils/HighScoreIO.h
+++ b/include/Utils/HighScoreIO.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <fstream>
+#include <algorithm>
+
+namespace FishGame {
+    struct HighScoreEntry {
+        std::string name;
+        int score{};
+    };
+
+    inline std::vector<HighScoreEntry> loadHighScores(const std::string& file) {
+        std::vector<HighScoreEntry> scores;
+        std::ifstream in(file);
+        std::string name; int score;
+        while (in >> name >> score) {
+            scores.push_back({name, score});
+        }
+        return scores;
+    }
+
+    inline void saveHighScores(const std::vector<HighScoreEntry>& scores, const std::string& file) {
+        std::ofstream out(file, std::ios::trunc);
+        for (const auto& e : scores) {
+            out << e.name << ' ' << e.score << '\n';
+        }
+    }
+
+    inline void addHighScore(const std::string& file, const HighScoreEntry& entry, std::size_t maxEntries = 10) {
+        auto scores = loadHighScores(file);
+        scores.push_back(entry);
+        std::sort(scores.begin(), scores.end(), [](const auto& a, const auto& b){ return a.score > b.score; });
+        if (scores.size() > maxEntries) scores.resize(maxEntries);
+        saveHighScores(scores, file);
+    }
+}

--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -1,6 +1,8 @@
 #include "Game.h"
 #include "IntroState.h"
+#include "PlayerNameState.h"
 #include "MenuState.h"
+#include "HighScoresState.h"
 #include "PlayState.h"
 #include "GameOverState.h"
 #include "GameOptionsState.h"
@@ -181,6 +183,7 @@ namespace FishGame
     {
         // Register all game states using template method
         registerState<IntroState>(StateID::Intro);
+        registerState<PlayerNameState>(StateID::PlayerName);
         registerState<MenuState>(StateID::Menu);
         registerState<StageIntroState>(StateID::StageIntro);
         registerState<StageSummaryState>(StateID::StageSummary);
@@ -195,6 +198,7 @@ namespace FishGame
         // Register optional states
         registerState<GameOptionsState>(StateID::GameOptions);
         registerState<GameOverState>(StateID::GameOver);
+        registerState<HighScoresState>(StateID::HighScores);
     }
 
 }

--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -58,6 +58,8 @@ namespace FishGame
         {TextureID::NewGameHover, "NewGameHover.png"},
         {TextureID::GameOptions, "GameOptions.png"},
         {TextureID::GameOptionsHover, "GameOptionsHover.png"},
+        {TextureID::HighScores, "HighScores.png"},
+        {TextureID::HighScoresHover, "HighScoresHover.png"},
         {TextureID::Exit, "Exit.png"},
         {TextureID::ExitHover, "ExitHover.png"},
         { TextureID::Intro1, "Intro1.png" },

--- a/src/States/HighScoresState.cpp
+++ b/src/States/HighScoresState.cpp
@@ -1,0 +1,79 @@
+#include "HighScoresState.h"
+#include "Game.h"
+#include <sstream>
+
+namespace FishGame {
+
+HighScoresState::HighScoresState(Game& game)
+    : State(game) {}
+
+void HighScoresState::onActivate() {
+    auto& fonts = getGame().getFonts();
+    auto& manager = getGame().getSpriteManager();
+    auto& window = getGame().getWindow();
+
+    m_titleText.setFont(fonts.get(Fonts::Main));
+    m_titleText.setString("HIGH SCORES");
+    m_titleText.setCharacterSize(48);
+    auto tb = m_titleText.getLocalBounds();
+    m_titleText.setOrigin(tb.width/2.f, tb.height/2.f);
+    m_titleText.setPosition(window.getSize().x/2.f, 150.f);
+
+    m_backButton.setTexture(manager.getTexture(TextureID::Button));
+    auto bb = m_backButton.getLocalBounds();
+    m_backButton.setOrigin(bb.width/2.f, bb.height/2.f);
+    m_backButton.setScale(Constants::MENU_BUTTON_SCALE, Constants::MENU_BUTTON_SCALE);
+    m_backButton.setPosition(window.getSize().x/2.f, window.getSize().y - 120.f);
+
+    loadScores();
+}
+
+void HighScoresState::loadScores() {
+    m_scores = loadHighScores("highscores.txt");
+    auto& font = getGame().getFonts().get(Fonts::Main);
+    m_scoreTexts.clear();
+    float startY = 250.f;
+    float spacing = 40.f;
+    for (std::size_t i=0;i<m_scores.size();++i) {
+        sf::Text text;
+        text.setFont(font);
+        std::ostringstream ss; ss<<i+1<<". "<<m_scores[i].name<<" - "<<m_scores[i].score;
+        text.setString(ss.str());
+        text.setCharacterSize(32);
+        auto b = text.getLocalBounds();
+        text.setOrigin(b.width/2.f, b.height/2.f);
+        text.setPosition(getGame().getWindow().getSize().x/2.f, startY + spacing*i);
+        m_scoreTexts.push_back(text);
+    }
+}
+
+void HighScoresState::handleEvent(const sf::Event& event) {
+    if(event.type==sf::Event::KeyPressed && event.key.code==sf::Keyboard::Escape){
+        deferAction([this](){ requestStackPop(); });
+    } else if(event.type==sf::Event::MouseMoved) {
+        sf::Vector2f pos(static_cast<float>(event.mouseMove.x), static_cast<float>(event.mouseMove.y));
+        bool h = m_backButton.getGlobalBounds().contains(pos);
+        if(h!=m_hover){
+            m_hover=h;
+            m_backButton.setTexture(getGame().getSpriteManager().getTexture(h?TextureID::ButtonHover:TextureID::Button));
+        }
+    } else if(event.type==sf::Event::MouseButtonPressed && event.mouseButton.button==sf::Mouse::Left){
+        sf::Vector2f pos(static_cast<float>(event.mouseButton.x), static_cast<float>(event.mouseButton.y));
+        if(m_backButton.getGlobalBounds().contains(pos))
+            deferAction([this](){ requestStackPop(); });
+    }
+}
+
+bool HighScoresState::update(sf::Time) {
+    processDeferredActions();
+    return false;
+}
+
+void HighScoresState::render() {
+    auto& window = getGame().getWindow();
+    window.draw(m_titleText);
+    for(const auto& t : m_scoreTexts) window.draw(t);
+    window.draw(m_backButton);
+}
+
+} // namespace FishGame

--- a/src/States/IntroState.cpp
+++ b/src/States/IntroState.cpp
@@ -46,7 +46,7 @@ namespace FishGame
         {
             deferAction([this]() {
                 requestStackPop();
-                requestStackPush(StateID::Menu);
+                requestStackPush(StateID::PlayerName);
                 });
         }
     }
@@ -69,7 +69,7 @@ namespace FishGame
             {
                 deferAction([this]() {
                     requestStackPop();
-                    requestStackPush(StateID::Menu);
+                    requestStackPush(StateID::PlayerName);
                     });
             }
         }

--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -56,6 +56,11 @@ namespace FishGame
                     requestStackPush(StateID::GameOptions);
                 });
             }},
+            {TextureID::HighScores, TextureID::HighScoresHover, [this]() {
+                deferAction([this]() {
+                    requestStackPush(StateID::HighScores);
+                });
+            }},
             {TextureID::Exit, TextureID::ExitHover, [this]() {
                 deferAction([this]() {
                     requestStackClear();

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -10,6 +10,7 @@
 #include "StageIntroState.h"
 #include "StageSummaryState.h"
 #include "MusicPlayer.h"
+#include "Utils/HighScoreIO.h"
 #include "GameConstants.h"
 #include <algorithm>
 #include <execution>
@@ -620,6 +621,8 @@ void PlayState::updateSpawning(sf::Time deltaTime)
         stats.newHighScore = stats.finalScore > stats.highScore;
         if (stats.newHighScore)
             stats.highScore = stats.finalScore;
+
+        addHighScore("highscores.txt", {stats.playerName, stats.finalScore});
 
         requestStackClear();
         requestStackPush(StateID::GameOver);

--- a/src/States/PlayerNameState.cpp
+++ b/src/States/PlayerNameState.cpp
@@ -1,0 +1,50 @@
+#include "PlayerNameState.h"
+#include "Game.h"
+#include "States/GameOverState.h"
+
+namespace FishGame {
+
+PlayerNameState::PlayerNameState(Game& game) : State(game) {}
+
+void PlayerNameState::onActivate(){
+    auto& font = getGame().getFonts().get(Fonts::Main);
+    auto& window = getGame().getWindow();
+    m_input.clear();
+    m_prompt.setFont(font);
+    m_prompt.setString("Enter Name:");
+    m_prompt.setCharacterSize(36);
+    auto pb=m_prompt.getLocalBounds();
+    m_prompt.setOrigin(pb.width/2.f, pb.height/2.f);
+    m_prompt.setPosition(window.getSize().x/2.f, window.getSize().y/2.f - 40.f);
+
+    m_inputText.setFont(font);
+    m_inputText.setCharacterSize(36);
+    m_inputText.setPosition(window.getSize().x/2.f, window.getSize().y/2.f + 10.f);
+    m_inputText.setOrigin(0.f, m_inputText.getLocalBounds().height/2.f);
+}
+
+void PlayerNameState::handleEvent(const sf::Event& event){
+    if(event.type==sf::Event::TextEntered){
+        if(event.text.unicode==8) { // backspace
+            if(!m_input.empty()) m_input.pop_back();
+        } else if(event.text.unicode==13){ // enter
+            GameStats::getInstance().playerName = m_input.empty()?"Player":m_input;
+            deferAction([this](){ requestStackPop(); requestStackPush(StateID::Menu); });
+        } else if(event.text.unicode>=32 && event.text.unicode<127 && m_input.size()<12){
+            m_input += static_cast<char>(event.text.unicode);
+        }
+        m_inputText.setString(m_input);
+        auto b=m_inputText.getLocalBounds();
+        m_inputText.setOrigin(b.width/2.f, b.height/2.f);
+    }
+}
+
+bool PlayerNameState::update(sf::Time){ processDeferredActions(); return false; }
+
+void PlayerNameState::render(){
+    auto& window=getGame().getWindow();
+    window.draw(m_prompt);
+    window.draw(m_inputText);
+}
+
+} // namespace FishGame


### PR DESCRIPTION
## Summary
- add PlayerName and HighScores states
- extend state enumerations
- register and implement new states
- store and load high scores from file
- show new button in menu

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68722a7b8e5483339d07673fd8f4bb78