### PR TITLE
Add backgrounds and deduplicate high scores

### DIFF
--- a/include/States/HighScoresState.h
+++ b/include/States/HighScoresState.h
@@ -25,5 +25,7 @@ private:
     std::vector<sf::Text> m_scoreTexts;
     sf::Sprite m_backButton;
     bool m_hover{false};
+    sf::Sprite m_backgroundSprite;
+    sf::Sprite m_overlaySprite;
 };
 }

--- a/include/States/PlayerNameState.h
+++ b/include/States/PlayerNameState.h
@@ -20,5 +20,7 @@ private:
     std::string m_input;
     sf::Text m_prompt;
     sf::Text m_inputText;
+    sf::Sprite m_backgroundSprite;
+    sf::Sprite m_overlaySprite;
 };
 }

--- a/include/Utils/HighScoreIO.h
+++ b/include/Utils/HighScoreIO.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <fstream>
 #include <algorithm>
+#include <unordered_map>
 
 namespace FishGame {
     struct HighScoreEntry {
@@ -11,12 +12,19 @@ namespace FishGame {
     };
 
     inline std::vector<HighScoreEntry> loadHighScores(const std::string& file) {
-        std::vector<HighScoreEntry> scores;
+        std::unordered_map<std::string,int> unique;
         std::ifstream in(file);
         std::string name; int score;
         while (in >> name >> score) {
-            scores.push_back({name, score});
+            auto it = unique.find(name);
+            if(it==unique.end() || score > it->second)
+                unique[name] = score;
         }
+        std::vector<HighScoreEntry> scores;
+        scores.reserve(unique.size());
+        for(const auto& p : unique)
+            scores.push_back({p.first, p.second});
+        std::sort(scores.begin(), scores.end(), [](const auto& a, const auto& b){ return a.score > b.score; });
         return scores;
     }
 
@@ -29,7 +37,15 @@ namespace FishGame {
 
     inline void addHighScore(const std::string& file, const HighScoreEntry& entry, std::size_t maxEntries = 10) {
         auto scores = loadHighScores(file);
-        scores.push_back(entry);
+        bool found = false;
+        for(auto& e : scores){
+            if(e.name == entry.name){
+                if(entry.score > e.score) e.score = entry.score;
+                found = true;
+                break;
+            }
+        }
+        if(!found) scores.push_back(entry);
         std::sort(scores.begin(), scores.end(), [](const auto& a, const auto& b){ return a.score > b.score; });
         if (scores.size() > maxEntries) scores.resize(maxEntries);
         saveHighScores(scores, file);

--- a/src/States/HighScoresState.cpp
+++ b/src/States/HighScoresState.cpp
@@ -5,12 +5,22 @@
 namespace FishGame {
 
 HighScoresState::HighScoresState(Game& game)
-    : State(game) {}
+    : State(game), m_hover(false), m_backgroundSprite(), m_overlaySprite() {}
 
 void HighScoresState::onActivate() {
     auto& fonts = getGame().getFonts();
     auto& manager = getGame().getSpriteManager();
     auto& window = getGame().getWindow();
+
+    m_backgroundSprite.setTexture(manager.getTexture(TextureID::Background1));
+    auto size = m_backgroundSprite.getTexture()->getSize();
+    m_backgroundSprite.setScale(static_cast<float>(window.getSize().x)/size.x,
+                               static_cast<float>(window.getSize().y)/size.y);
+
+    m_overlaySprite.setTexture(manager.getTexture(TextureID::StageIntro));
+    size = m_overlaySprite.getTexture()->getSize();
+    m_overlaySprite.setScale(static_cast<float>(window.getSize().x)/size.x,
+                             static_cast<float>(window.getSize().y)/size.y);
 
     m_titleText.setFont(fonts.get(Fonts::Main));
     m_titleText.setString("HIGH SCORES");
@@ -71,6 +81,8 @@ bool HighScoresState::update(sf::Time) {
 
 void HighScoresState::render() {
     auto& window = getGame().getWindow();
+    window.draw(m_backgroundSprite);
+    window.draw(m_overlaySprite);
     window.draw(m_titleText);
     for(const auto& t : m_scoreTexts) window.draw(t);
     window.draw(m_backButton);

--- a/src/States/PlayerNameState.cpp
+++ b/src/States/PlayerNameState.cpp
@@ -4,12 +4,24 @@
 
 namespace FishGame {
 
-PlayerNameState::PlayerNameState(Game& game) : State(game) {}
+PlayerNameState::PlayerNameState(Game& game)
+    : State(game), m_backgroundSprite(), m_overlaySprite() {}
 
 void PlayerNameState::onActivate(){
     auto& font = getGame().getFonts().get(Fonts::Main);
     auto& window = getGame().getWindow();
+    auto& manager = getGame().getSpriteManager();
     m_input.clear();
+
+    m_backgroundSprite.setTexture(manager.getTexture(TextureID::Background1));
+    auto size = m_backgroundSprite.getTexture()->getSize();
+    m_backgroundSprite.setScale(static_cast<float>(window.getSize().x)/size.x,
+                               static_cast<float>(window.getSize().y)/size.y);
+
+    m_overlaySprite.setTexture(manager.getTexture(TextureID::StageIntro));
+    size = m_overlaySprite.getTexture()->getSize();
+    m_overlaySprite.setScale(static_cast<float>(window.getSize().x)/size.x,
+                             static_cast<float>(window.getSize().y)/size.y);
     m_prompt.setFont(font);
     m_prompt.setString("Enter Name:");
     m_prompt.setCharacterSize(36);
@@ -43,6 +55,8 @@ bool PlayerNameState::update(sf::Time){ processDeferredActions(); return false; 
 
 void PlayerNameState::render(){
     auto& window=getGame().getWindow();
+    window.draw(m_backgroundSprite);
+    window.draw(m_overlaySprite);
     window.draw(m_prompt);
     window.draw(m_inputText);
 }


### PR DESCRIPTION
## Summary
- add background and overlay to PlayerName and HighScores screens
- deduplicate high scores using unordered structures

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68722f5c15c88333b647ddf3af7182da