### PR TITLE
Use unordered_set for unique high scores

### DIFF
--- a/include/States/HighScoresState.h
+++ b/include/States/HighScoresState.h
@@ -3,10 +3,23 @@
 #include "GameConstants.h"
 #include "Utils/HighScoreIO.h"
 #include <vector>
+#include <unordered_set>
 
 namespace FishGame {
 class HighScoresState;
 template<> struct is_state<HighScoresState> : std::true_type {};
+
+struct HighScoreEntryHash {
+    std::size_t operator()(const HighScoreEntry& e) const noexcept {
+        return std::hash<std::string>{}(e.name);
+    }
+};
+
+struct HighScoreEntryEqual {
+    bool operator()(const HighScoreEntry& a, const HighScoreEntry& b) const noexcept {
+        return a.name == b.name;
+    }
+};
 
 class HighScoresState : public State {
 public:
@@ -20,6 +33,7 @@ public:
 
 private:
     void loadScores();
+    std::unordered_set<HighScoreEntry, HighScoreEntryHash, HighScoreEntryEqual> m_scoreSet;
     std::vector<HighScoreEntry> m_scores;
     sf::Text m_titleText;
     std::vector<sf::Text> m_scoreTexts;

--- a/src/States/HighScoresState.cpp
+++ b/src/States/HighScoresState.cpp
@@ -1,6 +1,7 @@
 #include "HighScoresState.h"
 #include "Game.h"
 #include <sstream>
+#include <fstream>
 
 namespace FishGame {
 
@@ -39,7 +40,25 @@ void HighScoresState::onActivate() {
 }
 
 void HighScoresState::loadScores() {
-    m_scores = loadHighScores("highscores.txt");
+    m_scoreSet.clear();
+    std::ifstream in("highscores.txt");
+    std::string name; int score;
+    while(in >> name >> score) {
+        HighScoreEntry entry{name, score};
+        auto it = m_scoreSet.find(entry);
+        if(it == m_scoreSet.end()) {
+            m_scoreSet.insert(entry);
+        } else if(score > it->score) {
+            m_scoreSet.erase(it);
+            m_scoreSet.insert(entry);
+        }
+    }
+
+    m_scores.assign(m_scoreSet.begin(), m_scoreSet.end());
+    std::sort(m_scores.begin(), m_scores.end(), [](const auto& a, const auto& b){
+        return a.score > b.score;
+    });
+
     auto& font = getGame().getFonts().get(Fonts::Main);
     m_scoreTexts.clear();
     float startY = 250.f;


### PR DESCRIPTION
## Summary
- ensure high scores only keep the highest score for each name
- read scores using an unordered_set in `HighScoresState`

## Testing
- `cmake -S . -B build` *(fails: could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_687232ceed5c8333a1bd1871510ddede