### PR TITLE
Move exit button to bottom-right

### DIFF
--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -69,9 +69,10 @@ namespace FishGame
 
         // Setup menu items using STL algorithms
         float yPosition = Constants::MENU_START_Y;
+        size_t index = 0;
 
         std::transform(menuData.begin(), menuData.end(), m_menuItems.begin(),
-            [this, &window, &yPosition](const auto& data) -> MenuItemType {
+            [this, &window, &yPosition, &index](const auto& data) -> MenuItemType {
                 MenuItemType item;
                 item.normalTexture = std::get<0>(data);
                 item.hoverTexture = std::get<1>(data);
@@ -80,11 +81,19 @@ namespace FishGame
                 item.sprite.setTexture(getGame().getSpriteManager().getTexture(item.normalTexture));
                 sf::FloatRect bounds = item.sprite.getLocalBounds();
                 item.sprite.setOrigin(bounds.width / 2.0f, bounds.height / 2.0f);
-                item.sprite.setPosition(window.getSize().x / 2.0f, yPosition);
                 item.sprite.setScale(Constants::MENU_BUTTON_SCALE, Constants::MENU_BUTTON_SCALE);
 
-                yPosition += Constants::MENU_ITEM_SPACING;
+                sf::FloatRect scaledBounds = item.sprite.getGlobalBounds();
+                if (index == static_cast<size_t>(MenuOption::Exit)) {
+                    float xPos = static_cast<float>(window.getSize().x) - Constants::HUD_MARGIN - scaledBounds.width / 2.0f;
+                    float yPos = static_cast<float>(window.getSize().y) - Constants::HUD_MARGIN - scaledBounds.height / 2.0f;
+                    item.sprite.setPosition(xPos, yPos);
+                } else {
+                    item.sprite.setPosition(window.getSize().x / 2.0f, yPosition);
+                    yPosition += Constants::MENU_ITEM_SPACING;
+                }
 
+                ++index;
                 return item;
             });
 


### PR DESCRIPTION
## Summary
- reworked menu layout logic so the exit button appears at the bottom right of the screen

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687578b3435c8333bd13c4d202823329