### PR TITLE
Introduce strategy pattern for input handling

### DIFF
--- a/include/Systems/InputHandler.h
+++ b/include/Systems/InputHandler.h
@@ -2,15 +2,20 @@
 
 #include <SFML/Window/Event.hpp>
 #include <functional>
+#include <memory>
+#include "InputStrategy.h"
 
 namespace FishGame
 {
     class InputHandler
     {
     public:
-        void setReversed(bool reversed) { m_reversed = reversed; }
+        InputHandler();
+
+        void setReversed(bool reversed);
         void processEvent(sf::Event event, std::function<void(const sf::Event&)> callback);
+
     private:
-        bool m_reversed{false};
+        std::unique_ptr<IInputStrategy> m_strategy;
     };
 }

--- a/include/Systems/InputStrategy.h
+++ b/include/Systems/InputStrategy.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <SFML/Window/Event.hpp>
+
+namespace FishGame
+{
+    class IInputStrategy
+    {
+    public:
+        virtual ~IInputStrategy() = default;
+        virtual void process(sf::Event& event) = 0;
+    };
+
+    class NormalInputStrategy : public IInputStrategy
+    {
+    public:
+        void process(sf::Event& event) override;
+    };
+
+    class ReversedInputStrategy : public IInputStrategy
+    {
+    public:
+        void process(sf::Event& event) override;
+    };
+}

--- a/src/Systems/InputHandler.cpp
+++ b/src/Systems/InputHandler.cpp
@@ -1,21 +1,25 @@
 #include "InputHandler.h"
-#include <unordered_map>
+#include "InputStrategy.h"
 
 namespace FishGame
 {
+    InputHandler::InputHandler()
+        : m_strategy(std::make_unique<NormalInputStrategy>())
+    {
+    }
+
+    void InputHandler::setReversed(bool reversed)
+    {
+        if (reversed)
+            m_strategy = std::make_unique<ReversedInputStrategy>();
+        else
+            m_strategy = std::make_unique<NormalInputStrategy>();
+    }
+
     void InputHandler::processEvent(sf::Event event, std::function<void(const sf::Event&)> callback)
     {
-        if (m_reversed && event.type == sf::Event::KeyPressed)
-        {
-            static const std::unordered_map<sf::Keyboard::Key, sf::Keyboard::Key> map = {
-                {sf::Keyboard::W, sf::Keyboard::S}, {sf::Keyboard::S, sf::Keyboard::W},
-                {sf::Keyboard::A, sf::Keyboard::D}, {sf::Keyboard::D, sf::Keyboard::A},
-                {sf::Keyboard::Up, sf::Keyboard::Down}, {sf::Keyboard::Down, sf::Keyboard::Up},
-                {sf::Keyboard::Left, sf::Keyboard::Right}, {sf::Keyboard::Right, sf::Keyboard::Left}
-            };
-            if (auto it = map.find(event.key.code); it != map.end())
-                event.key.code = it->second;
-        }
+        if (m_strategy)
+            m_strategy->process(event);
         callback(event);
     }
 }

--- a/src/Systems/InputStrategy.cpp
+++ b/src/Systems/InputStrategy.cpp
@@ -1,0 +1,25 @@
+#include "InputStrategy.h"
+#include <unordered_map>
+
+namespace FishGame
+{
+    void NormalInputStrategy::process(sf::Event& /*event*/)
+    {
+        // No modification for normal controls
+    }
+
+    void ReversedInputStrategy::process(sf::Event& event)
+    {
+        if (event.type != sf::Event::KeyPressed)
+            return;
+
+        static const std::unordered_map<sf::Keyboard::Key, sf::Keyboard::Key> map = {
+            {sf::Keyboard::W, sf::Keyboard::S}, {sf::Keyboard::S, sf::Keyboard::W},
+            {sf::Keyboard::A, sf::Keyboard::D}, {sf::Keyboard::D, sf::Keyboard::A},
+            {sf::Keyboard::Up, sf::Keyboard::Down}, {sf::Keyboard::Down, sf::Keyboard::Up},
+            {sf::Keyboard::Left, sf::Keyboard::Right}, {sf::Keyboard::Right, sf::Keyboard::Left}
+        };
+        if (auto it = map.find(event.key.code); it != map.end())
+            event.key.code = it->second;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `IInputStrategy` interface with Normal and Reversed implementations
- update `InputHandler` to delegate to strategies instead of mutating events
- switch strategies when controls are reversed

## Testing
- `cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_687578e3c4808333a866b7055eb8f1b6