### PR TITLE
Refactor PlayState with controller components

### DIFF
--- a/include/States/EnvironmentController.h
+++ b/include/States/EnvironmentController.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "EnvironmentSystem.h"
+#include "Player.h"
+#include "Entity.h"
+#include "SoundPlayer.h"
+#include <vector>
+#include <memory>
+
+namespace FishGame {
+
+class EnvironmentController {
+public:
+    EnvironmentController(EnvironmentSystem& env, Player& player,
+                          std::vector<std::unique_ptr<Entity>>& entities,
+                          SoundPlayer& sounds);
+
+    void update(sf::Time dt);
+
+    void reset();
+
+    void applyFreeze();
+    void reverseControls();
+
+    bool isPlayerFrozen() const { return m_isPlayerFrozen; }
+    bool hasControlsReversed() const { return m_hasControlsReversed; }
+    bool isPlayerStunned() const { return m_isPlayerStunned; }
+
+    sf::Time getFreezeTimer() const { return m_freezeTimer; }
+    sf::Time getControlReverseTimer() const { return m_controlReverseTimer; }
+    sf::Time getStunTimer() const { return m_stunTimer; }
+
+    bool& stunnedRef() { return m_isPlayerStunned; }
+    sf::Time& stunTimerRef() { return m_stunTimer; }
+    sf::Time& controlReverseTimerRef() { return m_controlReverseTimer; }
+
+private:
+    void updateEffectTimers(sf::Time dt);
+    void applyEnvironmentalForces(sf::Time dt);
+
+    EnvironmentSystem& m_environment;
+    Player& m_player;
+    std::vector<std::unique_ptr<Entity>>& m_entities;
+    SoundPlayer& m_soundPlayer;
+
+    bool m_isPlayerFrozen{false};
+    bool m_hasControlsReversed{false};
+    bool m_isPlayerStunned{false};
+    sf::Time m_controlReverseTimer{sf::Time::Zero};
+    sf::Time m_freezeTimer{sf::Time::Zero};
+    sf::Time m_stunTimer{sf::Time::Zero};
+};
+
+}

--- a/include/States/HUDController.h
+++ b/include/States/HUDController.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "HUDSystem.h"
+#include <memory>
+
+namespace FishGame {
+
+class HUDController {
+public:
+    HUDController(const sf::Font& font, const sf::Vector2u& windowSize);
+
+    void update(sf::Time dt,
+                int score,
+                int lives,
+                int level,
+                int chainBonus,
+                const std::vector<PowerUpInfo>& active,
+                bool frozen, sf::Time freeze,
+                bool reversed, sf::Time reverse,
+                bool stunned, sf::Time stun);
+
+    void showMessage(const std::string& msg) { m_hud->showMessage(msg); }
+    HUDSystem& getSystem() { return *m_hud; }
+    float getFPS() const { return m_currentFPS; }
+
+private:
+    std::unique_ptr<HUDSystem> m_hud;
+    sf::Time m_fpsUpdate{sf::Time::Zero};
+    int m_frameCount{0};
+    float m_currentFPS{0.f};
+};
+
+} // namespace FishGame

--- a/include/States/PlayState.h
+++ b/include/States/PlayState.h
@@ -10,6 +10,9 @@
 #include "OysterManager.h"
 #include "ScoreSystem.h"
 #include "HUDSystem.h"
+#include "EnvironmentController.h"
+#include "SpawnController.h"
+#include "HUDController.h"
 #include "ParticleSystem.h"
 #include "SpawnSystem.h"
 #include "InputHandler.h"
@@ -22,7 +25,6 @@
 #include "BonusStageState.h"
 #include "GameConstants.h"
 #include "StateUtils.h"
-#include "SpawnTimer.h"
 #include <vector>
 #include <functional>
 #include <random>
@@ -71,14 +73,6 @@ namespace FishGame
 
         // HUD elements collection
 
-        // Performance metrics
-        struct PerformanceMetrics
-        {
-            sf::Time fpsUpdateTime = sf::Time::Zero;
-            int frameCount = 0;
-            float currentFPS = 0.0f;
-        };
-
         // ==================== Collision Handling ====================
 
         // ==================== Helper Functions ====================
@@ -88,10 +82,6 @@ namespace FishGame
         // Effect helpers
         void createParticleEffect(const sf::Vector2f& position, const sf::Color& color,
             int count = Constants::DEFAULT_PARTICLE_COUNT);
-        void applyEnvironmentalForces(sf::Time deltaTime);
-
-        // State helpers
-        void updateEffectTimers(sf::Time deltaTime);
 
         // ==================== Core Methods ====================
 
@@ -101,13 +91,9 @@ namespace FishGame
         // Update methods
         void updateGameplay(sf::Time deltaTime);
         void updateRespawn(sf::Time deltaTime);
-        void updateEnvironment(sf::Time deltaTime);
         void updateEntities(sf::Time deltaTime);
-        void updateSpawning(sf::Time deltaTime);
         void updateGameState(sf::Time deltaTime);
         void updateSystems(sf::Time deltaTime);
-        void updateHUD();
-        void updatePerformanceMetrics(sf::Time deltaTime);
         void updateCamera();
 
         // Collision handling
@@ -129,8 +115,6 @@ namespace FishGame
         // Helper methods
         bool areAllEnemiesGone() const;
         void makeAllEnemiesFlee();
-        void applyFreeze();
-        void reverseControls();
         void showMessage(const std::string& message);
         void updateBackground(int level);
 
@@ -142,9 +126,6 @@ namespace FishGame
         std::vector<std::unique_ptr<Entity>> m_entities;
         std::vector<std::unique_ptr<BonusItem>> m_bonusItems;
         std::vector<std::unique_ptr<Hazard>> m_hazards;
-
-        // Environmental system
-        std::unique_ptr<EnvironmentSystem> m_environmentSystem;
 
         // Game systems
         GameSystems m_systems;
@@ -159,18 +140,14 @@ namespace FishGame
 
         // State tracking
         GameStateData m_gameState;
-        std::unique_ptr<HUDSystem> m_hudSystem;
         std::unordered_map<TextureID, int> m_levelCounts;
 
-        // Effect states
-        bool m_isPlayerFrozen;
-        bool m_hasControlsReversed;
-        bool m_isPlayerStunned;
-        sf::Time m_controlReverseTimer;
-        sf::Time m_freezeTimer;
-        sf::Time m_stunTimer;
-        SpawnTimer<sf::Time> m_hazardSpawnTimer;
-        SpawnTimer<sf::Time> m_extendedPowerUpSpawnTimer;
+        // Controllers
+        std::unique_ptr<EnvironmentController> m_environmentController;
+        std::unique_ptr<SpawnController> m_spawnController;
+        std::unique_ptr<HUDController> m_hudController;
+        std::unique_ptr<EnvironmentSystem> m_environmentSystem;
+        std::unique_ptr<SpawnSystem> m_spawnSystem;
         InputHandler m_inputHandler;
 
         // Bonus stage tracking
@@ -179,7 +156,6 @@ namespace FishGame
         int m_savedLevel;
 
         // Performance tracking
-        PerformanceMetrics m_metrics;
 
         std::unique_ptr<ParticleSystem> m_particleSystem;
         std::unique_ptr<CollisionSystem> m_collisionSystem;
@@ -192,7 +168,6 @@ namespace FishGame
         std::mt19937 m_randomEngine;
         std::uniform_real_distribution<float> m_angleDist;
         std::uniform_real_distribution<float> m_speedDist;
-        std::unique_ptr<SpawnSystem> m_spawnSystem;
 
         bool m_initialized;
 

--- a/include/States/SpawnController.h
+++ b/include/States/SpawnController.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "EnhancedFishSpawner.h"
+#include "SpawnSystem.h"
+#include "BonusItemManager.h"
+#include "Entity.h"
+#include "Hazard.h"
+#include <memory>
+#include <vector>
+#include <random>
+#include "Utils/SpawnTimer.h"
+
+namespace FishGame {
+
+class SpawnController {
+public:
+    SpawnController(EnhancedFishSpawner& spawner,
+                    SpawnSystem& spawnSystem,
+                    BonusItemManager& bonusMgr,
+                    std::vector<std::unique_ptr<Entity>>& entities,
+                    std::vector<std::unique_ptr<BonusItem>>& bonus,
+                    std::vector<std::unique_ptr<Hazard>>& hazards);
+
+    void update(sf::Time dt, int level);
+
+private:
+    EnhancedFishSpawner& m_spawner;
+    SpawnSystem& m_spawnSystem;
+    BonusItemManager& m_bonusMgr;
+    std::vector<std::unique_ptr<Entity>>& m_entities;
+    std::vector<std::unique_ptr<BonusItem>>& m_bonusItems;
+    std::vector<std::unique_ptr<Hazard>>& m_hazards;
+
+    SpawnTimer<sf::Time> m_hazardSpawnTimer{sf::seconds(8.f)};
+    SpawnTimer<sf::Time> m_powerUpSpawnTimer{sf::seconds(15.f)};
+};
+
+} // namespace FishGame

--- a/src/States/EnvironmentController.cpp
+++ b/src/States/EnvironmentController.cpp
@@ -1,0 +1,89 @@
+#include "EnvironmentController.h"
+#include "Fish.h"
+#include "GameConstants.h"
+#include "EntityUtils.h"
+
+namespace FishGame {
+
+EnvironmentController::EnvironmentController(EnvironmentSystem& env,
+                                             Player& player,
+                                             std::vector<std::unique_ptr<Entity>>& entities,
+                                             SoundPlayer& sounds)
+    : m_environment(env), m_player(player), m_entities(entities), m_soundPlayer(sounds) {}
+
+void EnvironmentController::update(sf::Time dt)
+{
+    m_environment.update(dt);
+    updateEffectTimers(dt);
+    applyEnvironmentalForces(dt);
+}
+
+void EnvironmentController::updateEffectTimers(sf::Time dt)
+{
+    if (m_isPlayerFrozen) {
+        m_freezeTimer -= dt;
+        if (m_freezeTimer <= sf::Time::Zero) {
+            m_isPlayerFrozen = false;
+            EntityUtils::forEachAlive(m_entities, [](Entity& e) {
+                if (auto* f = dynamic_cast<Fish*>(&e))
+                    f->setFrozen(false);
+            });
+        }
+    }
+
+    if (m_hasControlsReversed) {
+        m_controlReverseTimer -= dt;
+        if (m_controlReverseTimer <= sf::Time::Zero) {
+            m_hasControlsReversed = false;
+            m_player.setControlsReversed(false);
+        }
+    }
+
+    if (m_isPlayerStunned) {
+        m_stunTimer -= dt;
+        if (m_stunTimer <= sf::Time::Zero)
+            m_isPlayerStunned = false;
+    }
+}
+
+void EnvironmentController::applyFreeze()
+{
+    m_isPlayerFrozen = true;
+    m_freezeTimer = sf::seconds(5.f);
+    m_soundPlayer.play(SoundEffectID::FreezePowerup);
+    EntityUtils::forEachAlive(m_entities, [](Entity& e) {
+        if (auto* f = dynamic_cast<Fish*>(&e))
+            f->setFrozen(true);
+    });
+}
+
+void EnvironmentController::reverseControls()
+{
+    m_hasControlsReversed = true;
+    m_player.setControlsReversed(true);
+}
+
+void EnvironmentController::applyEnvironmentalForces(sf::Time dt)
+{
+    if (!m_isPlayerStunned) {
+        sf::Vector2f force = m_environment.getOceanCurrentForce(m_player.getPosition());
+        m_player.setVelocity(m_player.getVelocity() + force * dt.asSeconds() * 0.3f);
+    }
+
+    EntityUtils::forEachAlive(m_entities, [this, dt](Entity& e) {
+        sf::Vector2f force = m_environment.getOceanCurrentForce(e.getPosition());
+        e.setVelocity(e.getVelocity() + force * dt.asSeconds() * 0.1f);
+    });
+}
+
+void EnvironmentController::reset()
+{
+    m_isPlayerFrozen = false;
+    m_hasControlsReversed = false;
+    m_isPlayerStunned = false;
+    m_controlReverseTimer = sf::Time::Zero;
+    m_freezeTimer = sf::Time::Zero;
+    m_stunTimer = sf::Time::Zero;
+}
+
+} // namespace FishGame

--- a/src/States/HUDController.cpp
+++ b/src/States/HUDController.cpp
@@ -1,0 +1,31 @@
+#include "HUDController.h"
+#include "GameConstants.h"
+
+namespace FishGame {
+
+HUDController::HUDController(const sf::Font& font, const sf::Vector2u& size)
+    : m_hud(std::make_unique<HUDSystem>(font, size)) {}
+
+void HUDController::update(sf::Time dt,
+                           int score,
+                           int lives,
+                           int level,
+                           int chainBonus,
+                           const std::vector<PowerUpInfo>& active,
+                           bool frozen, sf::Time freeze,
+                           bool reversed, sf::Time reverse,
+                           bool stunned, sf::Time stun)
+{
+    m_frameCount++;
+    m_fpsUpdate += dt;
+    if (m_fpsUpdate >= Constants::FPS_UPDATE_INTERVAL) {
+        m_currentFPS = static_cast<float>(m_frameCount) / m_fpsUpdate.asSeconds();
+        m_frameCount = 0;
+        m_fpsUpdate = sf::Time::Zero;
+    }
+
+    m_hud->update(score, lives, level, chainBonus, active,
+                  frozen, freeze, reversed, reverse, stunned, stun, m_currentFPS);
+}
+
+} // namespace FishGame

--- a/src/States/PlayLogic.cpp
+++ b/src/States/PlayLogic.cpp
@@ -57,7 +57,6 @@ void PlayLogic::handleEvent(const sf::Event& event)
 
 bool PlayLogic::update(sf::Time deltaTime)
 {
-    m_state.updatePerformanceMetrics(deltaTime);
     m_state.updateGameplay(deltaTime);
     m_state.processDeferredActions();
     return false;

--- a/src/States/SpawnController.cpp
+++ b/src/States/SpawnController.cpp
@@ -1,0 +1,41 @@
+#include "SpawnController.h"
+#include <algorithm>
+
+namespace FishGame {
+
+SpawnController::SpawnController(EnhancedFishSpawner& spawner,
+                                 SpawnSystem& spawnSystem,
+                                 BonusItemManager& bonusMgr,
+                                 std::vector<std::unique_ptr<Entity>>& entities,
+                                 std::vector<std::unique_ptr<BonusItem>>& bonus,
+                                 std::vector<std::unique_ptr<Hazard>>& hazards)
+    : m_spawner(spawner)
+    , m_spawnSystem(spawnSystem)
+    , m_bonusMgr(bonusMgr)
+    , m_entities(entities)
+    , m_bonusItems(bonus)
+    , m_hazards(hazards) {}
+
+void SpawnController::update(sf::Time dt, int level)
+{
+    m_spawner.update(dt, level);
+    auto& spawnedFish = m_spawner.getSpawnedFish();
+    std::move(spawnedFish.begin(), spawnedFish.end(), std::back_inserter(m_entities));
+    spawnedFish.clear();
+
+    if (m_hazardSpawnTimer.update(dt)) {
+        if (auto h = m_spawnSystem.spawnRandomHazard())
+            m_hazards.push_back(std::move(h));
+    }
+
+    if (m_powerUpSpawnTimer.update(dt)) {
+        if (auto p = m_spawnSystem.spawnRandomPowerUp())
+            m_bonusItems.push_back(std::move(p));
+    }
+
+    m_bonusMgr.update(dt);
+    auto newItems = m_bonusMgr.collectSpawnedItems();
+    std::move(newItems.begin(), newItems.end(), std::back_inserter(m_bonusItems));
+}
+
+} // namespace FishGame


### PR DESCRIPTION
## Summary
- introduce `EnvironmentController`, `SpawnController` and `HUDController`
- delegate spawning, environment and hud logic to new controllers
- update `PlayState` to orchestrate controllers and remove many helper methods
- adjust `PlayLogic` to use new `PlayState` interface

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_687578bf55348333a258665677740ac8