### PR TITLE
Fix PowerUpInfo type and missing include

### DIFF
--- a/include/States/HUDController.h
+++ b/include/States/HUDController.h
@@ -2,6 +2,7 @@
 
 #include "HUDSystem.h"
 #include <memory>
+#include <vector>
 
 namespace FishGame {
 
@@ -14,7 +15,7 @@ public:
                 int lives,
                 int level,
                 int chainBonus,
-                const std::vector<PowerUpInfo>& active,
+                const std::vector<PowerUpType>& active,
                 bool frozen, sf::Time freeze,
                 bool reversed, sf::Time reverse,
                 bool stunned, sf::Time stun);

--- a/src/States/EnvironmentController.cpp
+++ b/src/States/EnvironmentController.cpp
@@ -1,7 +1,7 @@
 #include "EnvironmentController.h"
 #include "Fish.h"
 #include "GameConstants.h"
-#include "EntityUtils.h"
+#include "Entity.h"
 
 namespace FishGame {
 

--- a/src/States/HUDController.cpp
+++ b/src/States/HUDController.cpp
@@ -11,7 +11,7 @@ void HUDController::update(sf::Time dt,
                            int lives,
                            int level,
                            int chainBonus,
-                           const std::vector<PowerUpInfo>& active,
+                           const std::vector<PowerUpType>& active,
                            bool frozen, sf::Time freeze,
                            bool reversed, sf::Time reverse,
                            bool stunned, sf::Time stun)

--- a/src/States/PlayLogic.cpp
+++ b/src/States/PlayLogic.cpp
@@ -9,10 +9,12 @@ PlayLogic::PlayLogic(PlayState& state) : m_state(state) {}
 
 void PlayLogic::handleEvent(const sf::Event& event)
 {
-    if (m_state.m_isPlayerStunned || m_state.getGame().getCurrentState<StageIntroState>())
+    if ((m_state.m_environmentController && m_state.m_environmentController->isPlayerStunned()) ||
+        m_state.getGame().getCurrentState<StageIntroState>())
         return;
 
-    m_state.m_inputHandler.setReversed(m_state.m_hasControlsReversed);
+    if (m_state.m_environmentController)
+        m_state.m_inputHandler.setReversed(m_state.m_environmentController->hasControlsReversed());
     m_state.m_inputHandler.processEvent(event, [this](const sf::Event& processedEvent)
     {
         switch (processedEvent.type)


### PR DESCRIPTION
## Summary
- include correct header for entity utilities
- use `PowerUpType` vector instead of undefined `PowerUpInfo`
- adjust input handling to check state from `EnvironmentController`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68757d7258ac83338f14603f74f65c23