### PR TITLE
Fix CollisionSystem member access

### DIFF
--- a/include/Systems/CollisionSystem.h
+++ b/include/Systems/CollisionSystem.h
@@ -36,7 +36,8 @@ namespace FishGame
                      std::vector<std::unique_ptr<Hazard>>& hazards,
                      FixedOysterManager* oysters, int currentLevel);
 
-    private:
+    public:
+        // Exposed for entity collision handlers
         void createParticle(const sf::Vector2f& pos, const sf::Color& color, int count = Constants::DEFAULT_PARTICLE_COUNT);
         void handlePowerUpCollision(Player& player, PowerUp& powerUp);
         void handleOysterCollision(Player& player, PermanentOyster* oyster);


### PR DESCRIPTION
## Summary
- expose CollisionSystem internals to entities that need them

## Testing
- `cmake .. && cmake --build . -j4` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6875810d285483339a1153869032c38c