### PR TITLE
Fix lambda usage for collisions

### DIFF
--- a/src/Systems/CollisionSystem.cpp
+++ b/src/Systems/CollisionSystem.cpp
@@ -119,14 +119,14 @@ namespace FishGame
         });
 
         EntityUtils::forEachAlive(bonusItems, [this,&player](auto& e){
-            if (EntityUtils::areColliding(player, *e)) {
-                e->onCollide(player, *this);
+            if (EntityUtils::areColliding(player, e)) {
+                e.onCollide(player, *this);
             }
         });
 
         EntityUtils::forEachAlive(hazards, [this,&player](auto& h){
-            if (EntityUtils::areColliding(player, *h)) {
-                h->onCollide(player, *this);
+            if (EntityUtils::areColliding(player, h)) {
+                h.onCollide(player, *this);
             }
         });
 


### PR DESCRIPTION
## Summary
- update lambda captures in `CollisionSystem` to use direct object access

## Testing
- `cmake -S . -B build` *(fails: could not find package `SFML`)*
- `apt-get update` *(fails: blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_6875829433c483339a0f63f0680a8b2e