### PR TITLE
Refactor Player helpers to use public interfaces

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -20,10 +20,14 @@ namespace FishGame
 
     class Player : public Entity
     {
-        friend class PlayerInput;
-        friend class PlayerGrowth;
-        friend class PlayerVisual;
     public:
+        struct VisualEffect
+        {
+            float scale = 1.f;
+            float rotation = 0.f;
+            sf::Color color = sf::Color::White;
+            sf::Time duration = sf::Time::Zero;
+        };
         Player();
         ~Player() override;
 
@@ -83,6 +87,59 @@ namespace FishGame
         // Size information
         bool isAtMaxSize() const { return m_currentStage >= Constants::MAX_STAGES; }
         void setWindowBounds(const sf::Vector2u& windowSize);
+
+        // Accessors used by helper classes
+        bool areControlsReversed() const { return m_controlsReversed; }
+        sf::Time getPoisonColorTimer() const { return m_poisonColorTimer; }
+        void setPoisonColorTimer(sf::Time t) { m_poisonColorTimer = t; }
+
+        sf::Time getSpeedBoostTimer() const { return m_speedBoostTimer; }
+        float getSpeedMultiplier() const { return m_speedMultiplier; }
+
+        int getCurrentStage() const { return m_currentStage; }
+        void setCurrentStage(int stage) { m_currentStage = stage; }
+
+        float getGrowthProgress() const { return m_growthProgress; }
+        void setGrowthProgress(float value) { m_growthProgress = value; }
+        void addGrowthProgress(float delta) { m_growthProgress += delta; }
+
+        int getScore() const { return m_score; }
+        void setScore(int score) { m_score = score; }
+
+        void setPoints(int points) { m_points = points; }
+        void incrementPoints(int amount) { m_points += amount; }
+
+        SoundPlayer* getSoundPlayer() const { return m_soundPlayer; }
+        GrowthMeter* getGrowthMeter() const { return m_growthMeter; }
+        SpriteManager* getSpriteManager() const { return m_spriteManager; }
+        Animator* getAnimator() const { return m_animator.get(); }
+        std::vector<VisualEffect>& getActiveEffects() { return m_activeEffects; }
+        const std::vector<VisualEffect>& getActiveEffects() const { return m_activeEffects; }
+
+        sf::Time getEatAnimationTimer() const { return m_eatAnimationTimer; }
+        void setEatAnimationTimer(sf::Time t) { m_eatAnimationTimer = t; }
+        float getEatAnimationScale() const { return m_eatAnimationScale; }
+        void setEatAnimationScale(float s) { m_eatAnimationScale = s; }
+        sf::Time getTurnAnimationTimer() const { return m_turnAnimationTimer; }
+        void setTurnAnimationTimer(sf::Time t) { m_turnAnimationTimer = t; }
+        float getDamageFlashIntensity() const { return m_damageFlashIntensity; }
+        void setDamageFlashIntensity(float f) { m_damageFlashIntensity = f; }
+        sf::Color getDamageFlashColor() const { return m_damageFlashColor; }
+        void setDamageFlashColor(sf::Color c) { m_damageFlashColor = c; }
+        const std::string& getCurrentAnimation() const { return m_currentAnimation; }
+        void setCurrentAnimation(const std::string& anim) { m_currentAnimation = anim; }
+        bool isFacingRight() const { return m_facingRight; }
+        sf::Time getInvulnerabilityTimer() const { return m_invulnerabilityTimer; }
+
+        static constexpr float baseSpeed() { return m_baseSpeed; }
+        static constexpr float baseRadius() { return m_baseRadius; }
+        static constexpr float growthFactor() { return m_growthFactor; }
+        static constexpr float tinyFishGrowth() { return m_tinyFishGrowth; }
+        static constexpr float smallFishGrowth() { return m_smallFishGrowth; }
+        static constexpr float mediumFishGrowth() { return m_mediumFishGrowth; }
+        static constexpr float eatAnimationSpeed() { return m_eatAnimationSpeed; }
+        static sf::Time eatAnimationDuration() { return m_eatAnimationDuration; }
+        static sf::Time turnAnimationDuration() { return m_turnAnimationDuration; }
 
         // Statistics tracking
 
@@ -154,13 +211,6 @@ namespace FishGame
         sf::Vector2u m_windowBounds;
 
         // Visual effects
-        struct VisualEffect
-        {
-            float scale = 1.f;
-            float rotation = 0.f;
-            sf::Color color = sf::Color::White;
-            sf::Time duration = sf::Time::Zero;
-        };
         std::vector<VisualEffect> m_activeEffects;
 
         // Eat animation

--- a/src/Entities/PlayerGrowth.cpp
+++ b/src/Entities/PlayerGrowth.cpp
@@ -11,59 +11,58 @@ void PlayerGrowth::grow(int scoreValue)
 {
     float growthPoints = 0.f;
     if (scoreValue <= 3)
-        growthPoints = Player::m_tinyFishGrowth;
+        growthPoints = Player::tinyFishGrowth();
     else if (scoreValue <= 6)
-        growthPoints = Player::m_smallFishGrowth;
+        growthPoints = Player::smallFishGrowth();
     else if (scoreValue <= 9)
-        growthPoints = Player::m_mediumFishGrowth;
+        growthPoints = Player::mediumFishGrowth();
     else
         growthPoints = static_cast<float>(scoreValue);
 
-    m_player.m_growthProgress += growthPoints;
+    m_player.addGrowthProgress(growthPoints);
 
-    if (m_player.m_growthMeter)
+    if (auto meter = m_player.getGrowthMeter())
     {
-        m_player.m_growthMeter->setPoints(m_player.m_points);
+        meter->setPoints(m_player.getPoints());
     }
 
-    if (m_player.m_visual)
-        m_player.m_visual->triggerEatEffect();
+    m_player.triggerEatEffect();
 }
 
 void PlayerGrowth::addPoints(int points)
 {
-    m_player.m_points += points;
-    if (m_player.m_growthMeter)
+    m_player.incrementPoints(points);
+    if (auto meter = m_player.getGrowthMeter())
     {
-        m_player.m_growthMeter->setPoints(m_player.m_points);
+        meter->setPoints(m_player.getPoints());
     }
 }
 
 void PlayerGrowth::checkStageAdvancement()
 {
-    if (m_player.m_currentStage == 1 && m_player.m_points >= Constants::POINTS_FOR_STAGE_2)
+    if (m_player.getCurrentStage() == 1 && m_player.getPoints() >= Constants::POINTS_FOR_STAGE_2)
     {
-        m_player.m_currentStage = 2;
+        m_player.setCurrentStage(2);
         updateStage();
     }
-    else if (m_player.m_currentStage == 2 && m_player.m_points >= Constants::POINTS_FOR_STAGE_3)
+    else if (m_player.getCurrentStage() == 2 && m_player.getPoints() >= Constants::POINTS_FOR_STAGE_3)
     {
-        m_player.m_currentStage = 3;
+        m_player.setCurrentStage(3);
         updateStage();
     }
 }
 
 void PlayerGrowth::resetSize()
 {
-    m_player.m_score = 0;
-    m_player.m_currentStage = 1;
-    m_player.m_growthProgress = 0.f;
-    m_player.m_radius = Player::m_baseRadius;
+    m_player.setScore(0);
+    m_player.setCurrentStage(1);
+    m_player.setGrowthProgress(0.f);
+    m_player.setRadius(Player::baseRadius());
 
-    if (m_player.m_growthMeter)
+    if (auto meter = m_player.getGrowthMeter())
     {
-        m_player.m_growthMeter->reset();
-        m_player.m_growthMeter->setStage(1);
+        meter->reset();
+        meter->setStage(1);
     }
 
     updateStage();
@@ -72,30 +71,30 @@ void PlayerGrowth::resetSize()
 void PlayerGrowth::fullReset()
 {
     resetSize();
-    m_player.m_points = 0;
-    m_player.m_controlsReversed = false;
-    m_player.m_poisonColorTimer = sf::Time::Zero;
+    m_player.setPoints(0);
+    m_player.setControlsReversed(false);
+    m_player.setPoisonColorTimer(sf::Time::Zero);
 }
 
 void PlayerGrowth::updateStage()
 {
-    if (m_player.m_soundPlayer && m_player.m_currentStage == 1)
-        m_player.m_soundPlayer->play(SoundEffectID::StageIntro);
-    else if (m_player.m_soundPlayer)
-        m_player.m_soundPlayer->play(SoundEffectID::PlayerGrow);
+    if (m_player.getSoundPlayer() && m_player.getCurrentStage() == 1)
+        m_player.getSoundPlayer()->play(SoundEffectID::StageIntro);
+    else if (m_player.getSoundPlayer())
+        m_player.getSoundPlayer()->play(SoundEffectID::PlayerGrow);
 
-    m_player.m_radius = static_cast<float>(Player::m_baseRadius *
-        std::pow(Player::m_growthFactor, static_cast<float>(m_player.m_currentStage - 1)));
+    m_player.setRadius(static_cast<float>(Player::baseRadius() *
+        std::pow(Player::growthFactor(), static_cast<float>(m_player.getCurrentStage() - 1))));
 
-    if (m_player.m_growthMeter)
+    if (auto meter = m_player.getGrowthMeter())
     {
-        m_player.m_growthMeter->setStage(m_player.m_currentStage);
+        meter->setStage(m_player.getCurrentStage());
     }
 
-    if (m_player.m_animator && m_player.m_renderMode == Entity::RenderMode::Sprite && m_player.m_spriteManager)
+    if (m_player.getAnimator() && m_player.getRenderMode() == Entity::RenderMode::Sprite && m_player.getSpriteManager())
     {
         float stageScale = 1.f;
-        const auto& cfg = m_player.m_spriteManager->getScaleConfig();
+        const auto& cfg = m_player.getSpriteManager()->getScaleConfig();
         switch (m_player.getCurrentFishSize())
         {
         case FishSize::Small:
@@ -111,10 +110,10 @@ void PlayerGrowth::updateStage()
             stageScale = 1.f;
             break;
         }
-        m_player.m_animator->setScale(sf::Vector2f(stageScale, stageScale));
+        m_player.getAnimator()->setScale(sf::Vector2f(stageScale, stageScale));
     }
 
-    m_player.m_activeEffects.push_back({1.5f, 0.f, sf::Color::Cyan, sf::seconds(0.5f)});
+    m_player.getActiveEffects().push_back({1.5f, 0.f, sf::Color::Cyan, sf::seconds(0.5f)});
 }
 
 } // namespace FishGame

--- a/src/Entities/PlayerInput.cpp
+++ b/src/Entities/PlayerInput.cpp
@@ -33,7 +33,7 @@ void PlayerInput::handleInput()
         keyboardUsed = true;
     }
 
-    if (m_player.m_controlsReversed)
+    if (m_player.areControlsReversed())
     {
         inputDirection = -inputDirection;
     }
@@ -44,13 +44,14 @@ void PlayerInput::handleInput()
         if (length > 0.f)
         {
             inputDirection /= length;
-            float speed = Player::m_baseSpeed * (m_player.m_speedBoostTimer > sf::Time::Zero ? m_player.m_speedMultiplier : 1.f);
-            m_player.m_velocity = inputDirection * speed;
+            float speed = Player::baseSpeed() *
+                (m_player.getSpeedBoostTimer() > sf::Time::Zero ? m_player.getSpeedMultiplier() : 1.f);
+            m_player.setVelocity(inputDirection * speed);
         }
     }
     else
     {
-        m_player.m_velocity *= 0.9f;
+        m_player.setVelocity(m_player.getVelocity() * 0.9f);
     }
 }
 

--- a/src/Entities/PlayerVisual.cpp
+++ b/src/Entities/PlayerVisual.cpp
@@ -9,87 +9,87 @@ PlayerVisual::PlayerVisual(Player& player) : m_player(player) {}
 
 void PlayerVisual::triggerEatEffect()
 {
-    m_player.m_eatAnimationScale = 1.3f;
-    m_player.m_eatAnimationTimer = Player::m_eatAnimationDuration;
+    m_player.setEatAnimationScale(1.3f);
+    m_player.setEatAnimationTimer(Player::eatAnimationDuration());
 
-    if (m_player.m_animator)
+    if (m_player.getAnimator())
     {
-        std::string eatAnim = m_player.m_facingRight ? "eatRight" : "eatLeft";
-        m_player.m_animator->play(eatAnim);
-        m_player.m_currentAnimation = eatAnim;
+        std::string eatAnim = m_player.isFacingRight() ? "eatRight" : "eatLeft";
+        m_player.getAnimator()->play(eatAnim);
+        m_player.setCurrentAnimation(eatAnim);
     }
 
-    m_player.m_activeEffects.push_back({1.2f, 0.f, sf::Color::Green, sf::seconds(0.2f)});
+    m_player.getActiveEffects().push_back({1.2f, 0.f, sf::Color::Green, sf::seconds(0.2f)});
 }
 
 void PlayerVisual::triggerDamageEffect()
 {
-    m_player.m_damageFlashIntensity = 1.f;
-    m_player.m_damageFlashColor = sf::Color::Red;
+    m_player.setDamageFlashIntensity(1.f);
+    m_player.setDamageFlashColor(sf::Color::Red);
 
-    m_player.m_activeEffects.push_back({0.8f, 15.f, sf::Color::Red, sf::seconds(0.3f)});
+    m_player.getActiveEffects().push_back({0.8f, 15.f, sf::Color::Red, sf::seconds(0.3f)});
 }
 
 void PlayerVisual::update(sf::Time deltaTime)
 {
-    if (m_player.m_eatAnimationTimer > sf::Time::Zero)
+    if (m_player.getEatAnimationTimer() > sf::Time::Zero)
     {
-        m_player.m_eatAnimationTimer -= deltaTime;
-        if (m_player.m_eatAnimationTimer < sf::Time::Zero)
-            m_player.m_eatAnimationTimer = sf::Time::Zero;
+        m_player.setEatAnimationTimer(m_player.getEatAnimationTimer() - deltaTime);
+        if (m_player.getEatAnimationTimer() < sf::Time::Zero)
+            m_player.setEatAnimationTimer(sf::Time::Zero);
     }
 
-    if (m_player.m_turnAnimationTimer > sf::Time::Zero)
+    if (m_player.getTurnAnimationTimer() > sf::Time::Zero)
     {
-        m_player.m_turnAnimationTimer -= deltaTime;
-        if (m_player.m_turnAnimationTimer < sf::Time::Zero)
-            m_player.m_turnAnimationTimer = sf::Time::Zero;
+        m_player.setTurnAnimationTimer(m_player.getTurnAnimationTimer() - deltaTime);
+        if (m_player.getTurnAnimationTimer() < sf::Time::Zero)
+            m_player.setTurnAnimationTimer(sf::Time::Zero);
     }
 
-    if (m_player.m_eatAnimationScale > 1.f)
+    if (m_player.getEatAnimationScale() > 1.f)
     {
-        m_player.m_eatAnimationScale -= Player::m_eatAnimationSpeed * deltaTime.asSeconds();
-        m_player.m_eatAnimationScale = std::max(1.f, m_player.m_eatAnimationScale);
+        m_player.setEatAnimationScale(m_player.getEatAnimationScale() - Player::eatAnimationSpeed() * deltaTime.asSeconds());
+        m_player.setEatAnimationScale(std::max(1.f, m_player.getEatAnimationScale()));
     }
 
-    if (m_player.m_damageFlashIntensity > 0.f)
+    if (m_player.getDamageFlashIntensity() > 0.f)
     {
-        m_player.m_damageFlashIntensity -= 3.f * deltaTime.asSeconds();
-        m_player.m_damageFlashIntensity = std::max(0.f, m_player.m_damageFlashIntensity);
+        m_player.setDamageFlashIntensity(m_player.getDamageFlashIntensity() - 3.f * deltaTime.asSeconds());
+        m_player.setDamageFlashIntensity(std::max(0.f, m_player.getDamageFlashIntensity()));
     }
 
-    if (m_player.m_poisonColorTimer > sf::Time::Zero)
+    if (m_player.getPoisonColorTimer() > sf::Time::Zero)
     {
-        m_player.m_poisonColorTimer -= deltaTime;
-        if (m_player.m_poisonColorTimer <= sf::Time::Zero)
+        m_player.setPoisonColorTimer(m_player.getPoisonColorTimer() - deltaTime);
+        if (m_player.getPoisonColorTimer() <= sf::Time::Zero)
         {
-            m_player.m_poisonColorTimer = sf::Time::Zero;
-            m_player.m_controlsReversed = false;
+            m_player.setPoisonColorTimer(sf::Time::Zero);
+            m_player.setControlsReversed(false);
         }
     }
 
-    std::for_each(m_player.m_activeEffects.begin(), m_player.m_activeEffects.end(),
+    std::for_each(m_player.getActiveEffects().begin(), m_player.getActiveEffects().end(),
         [deltaTime](Player::VisualEffect& effect) { effect.duration -= deltaTime; });
 
-    m_player.m_activeEffects.erase(
-        std::remove_if(m_player.m_activeEffects.begin(), m_player.m_activeEffects.end(),
+    m_player.getActiveEffects().erase(
+        std::remove_if(m_player.getActiveEffects().begin(), m_player.getActiveEffects().end(),
             [](const Player::VisualEffect& effect) { return effect.duration <= sf::Time::Zero; }),
-        m_player.m_activeEffects.end());
+        m_player.getActiveEffects().end());
 
     sf::Color currentColor = sf::Color::White;
 
-    if (m_player.m_invulnerabilityTimer > sf::Time::Zero)
+    if (m_player.getInvulnerabilityTimer() > sf::Time::Zero)
     {
-        float alpha = std::sin(m_player.m_invulnerabilityTimer.asSeconds() * 10.f) * 0.5f + 0.5f;
+        float alpha = std::sin(m_player.getInvulnerabilityTimer().asSeconds() * 10.f) * 0.5f + 0.5f;
         currentColor.a = static_cast<sf::Uint8>(255 * alpha);
     }
-    else if (m_player.m_damageFlashIntensity > 0.f)
+    else if (m_player.getDamageFlashIntensity() > 0.f)
     {
-        currentColor.r = static_cast<sf::Uint8>(currentColor.r + (m_player.m_damageFlashColor.r - currentColor.r) * m_player.m_damageFlashIntensity);
-        currentColor.g = static_cast<sf::Uint8>(currentColor.g + (m_player.m_damageFlashColor.g - currentColor.g) * m_player.m_damageFlashIntensity);
-        currentColor.b = static_cast<sf::Uint8>(currentColor.b + (m_player.m_damageFlashColor.b - currentColor.b) * m_player.m_damageFlashIntensity);
+        currentColor.r = static_cast<sf::Uint8>(currentColor.r + (m_player.getDamageFlashColor().r - currentColor.r) * m_player.getDamageFlashIntensity());
+        currentColor.g = static_cast<sf::Uint8>(currentColor.g + (m_player.getDamageFlashColor().g - currentColor.g) * m_player.getDamageFlashIntensity());
+        currentColor.b = static_cast<sf::Uint8>(currentColor.b + (m_player.getDamageFlashColor().b - currentColor.b) * m_player.getDamageFlashIntensity());
     }
-    else if (m_player.m_poisonColorTimer > sf::Time::Zero)
+    else if (m_player.getPoisonColorTimer() > sf::Time::Zero)
     {
         currentColor = sf::Color(50, 255, 50);
     }
@@ -98,32 +98,32 @@ void PlayerVisual::update(sf::Time deltaTime)
         currentColor.a = 255;
     }
 
-    if (m_player.m_animator)
-        m_player.m_animator->setColor(currentColor);
+    if (m_player.getAnimator())
+        m_player.getAnimator()->setColor(currentColor);
 }
 
 void PlayerVisual::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {
-    if (!m_player.m_isAlive)
+    if (!m_player.isAlive())
         return;
 
-    for (const auto& effect : m_player.m_activeEffects)
+    for (const auto& effect : m_player.getActiveEffects())
     {
         if (effect.duration > sf::Time::Zero)
         {
             sf::Transform effectTransform;
-            effectTransform.translate(m_player.m_position);
+            effectTransform.translate(m_player.getPosition());
             effectTransform.scale(effect.scale, effect.scale);
             effectTransform.rotate(effect.rotation);
-            effectTransform.translate(-m_player.m_position);
+            effectTransform.translate(-m_player.getPosition());
 
             states.transform *= effectTransform;
         }
     }
 
-    if (m_player.m_animator)
+    if (m_player.getAnimator())
     {
-        target.draw(*m_player.m_animator, states);
+        target.draw(*m_player.getAnimator(), states);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove friend access from Player
- add getter and setter interface for Player state
- refactor helper classes to use the new interface
- expose constants needed by the helpers

## Testing
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_687578cd29d08333bc081f6a49fa0917