### PR TITLE
Implement applyEffect for power-ups

### DIFF
--- a/include/Entities/ExtendedPowerUps.h
+++ b/include/Entities/ExtendedPowerUps.h
@@ -16,6 +16,7 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Cyan; }
+        void applyEffect(Player& player, CollisionSystem& system) override;
 
         void setFont(const sf::Font& font) { m_icon.setFont(font); }
 
@@ -38,6 +39,7 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Green; }
+        void applyEffect(Player& player, CollisionSystem& system) override;
 
         void initializeSprite(SpriteManager& spriteManager);
 
@@ -60,6 +62,7 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color(0, 255, 255); }
+        void applyEffect(Player& player, CollisionSystem& system) override;
 
         void initializeSprite(SpriteManager& spriteManager);
 
@@ -83,6 +86,7 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::White; }
+        void applyEffect(Player& player, CollisionSystem& system) override;
 
         void initializeSprite(SpriteManager& spriteManager);
 

--- a/include/Entities/PowerUp.h
+++ b/include/Entities/PowerUp.h
@@ -32,6 +32,9 @@ namespace FishGame
         // Visual indicator
         virtual sf::Color getAuraColor() const = 0;
 
+        // Apply the specific effect to the player and collision system
+        virtual void applyEffect(Player& player, CollisionSystem& system) = 0;
+
         void onCollide(Player& player, CollisionSystem& system) override;
 
     protected:
@@ -54,6 +57,7 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Yellow; }
+        void applyEffect(Player& player, CollisionSystem& system) override;
 
         void setFont(const sf::Font& font) { m_icon.setFont(font); }
 
@@ -74,6 +78,7 @@ namespace FishGame
         void update(sf::Time deltaTime) override;
         void onCollect() override;
         sf::Color getAuraColor() const override { return sf::Color::Magenta; }
+        void applyEffect(Player& player, CollisionSystem& system) override;
 
     protected:
         void draw(sf::RenderTarget& target, sf::RenderStates states) const override;

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -6,6 +6,7 @@
 #include <execution>
 #include "Utils/DrawHelpers.h"
 #include "SpriteManager.h"
+#include "Systems/CollisionSystem.h"
 
 namespace FishGame
 {
@@ -76,10 +77,17 @@ namespace FishGame
         m_aura.setOutlineColor(auraColor);
     }
 
-    void FreezePowerUp::onCollect()
-    {
-        destroy();
-    }
+void FreezePowerUp::onCollect()
+{
+    destroy();
+}
+
+void FreezePowerUp::applyEffect(Player& player, CollisionSystem& system)
+{
+    system.m_powerUps.activatePowerUp(getPowerUpType(), getDuration());
+    system.m_applyFreeze();
+    system.createParticle(getPosition(), sf::Color::Cyan, 20);
+}
 
     void FreezePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -134,10 +142,17 @@ namespace FishGame
         m_aura.setOutlineColor(auraColor);
     }
 
-    void ExtraLifePowerUp::onCollect()
-    {
-        destroy();
-    }
+void ExtraLifePowerUp::onCollect()
+{
+    destroy();
+}
+
+void ExtraLifePowerUp::applyEffect(Player& player, CollisionSystem& system)
+{
+    system.m_playerLives++;
+    system.m_sounds.play(SoundEffectID::LifePowerup);
+    system.createParticle(getPosition(), sf::Color::Green, 15);
+}
 
     void ExtraLifePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -224,10 +239,18 @@ namespace FishGame
         m_aura.setOutlineColor(auraColor);
     }
 
-    void SpeedBoostPowerUp::onCollect()
-    {
-        destroy();
-    }
+void SpeedBoostPowerUp::onCollect()
+{
+    destroy();
+}
+
+void SpeedBoostPowerUp::applyEffect(Player& player, CollisionSystem& system)
+{
+    system.m_powerUps.activatePowerUp(getPowerUpType(), getDuration());
+    player.applySpeedBoost(system.m_powerUps.getSpeedMultiplier(), getDuration());
+    system.m_sounds.play(SoundEffectID::SpeedStart);
+    system.createParticle(getPosition(), Constants::SPEED_BOOST_COLOR);
+}
 
     void SpeedBoostPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -268,10 +291,15 @@ namespace FishGame
             getSpriteComponent()->syncWithOwner();
     }
 
-    void AddTimePowerUp::onCollect()
-    {
-        destroy();
-    }
+void AddTimePowerUp::onCollect()
+{
+    destroy();
+}
+
+void AddTimePowerUp::applyEffect(Player& player, CollisionSystem& system)
+{
+    // No effect defined yet
+}
 
     void AddTimePowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -89,10 +89,16 @@ namespace FishGame
         m_aura.setOutlineColor(auraColor);
     }
 
-    void ScoreDoublerPowerUp::onCollect()
-    {
-        destroy();
-    }
+void ScoreDoublerPowerUp::onCollect()
+{
+    destroy();
+}
+
+void ScoreDoublerPowerUp::applyEffect(Player& player, CollisionSystem& system)
+{
+    system.m_powerUps.activatePowerUp(getPowerUpType(), getDuration());
+    system.createParticle(getPosition(), Constants::SCORE_DOUBLER_COLOR);
+}
 
     void ScoreDoublerPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {
@@ -163,10 +169,16 @@ namespace FishGame
         m_aura.setOutlineColor(auraColor);
     }
 
-    void FrenzyStarterPowerUp::onCollect()
-    {
-        destroy();
-    }
+void FrenzyStarterPowerUp::onCollect()
+{
+    destroy();
+}
+
+void FrenzyStarterPowerUp::applyEffect(Player& player, CollisionSystem& system)
+{
+    system.m_frenzySystem.forceFrenzy();
+    system.createParticle(getPosition(), Constants::FRENZY_STARTER_COLOR);
+}
 
     void FrenzyStarterPowerUp::draw(sf::RenderTarget& target, sf::RenderStates states) const
     {

--- a/src/Systems/CollisionSystem.cpp
+++ b/src/Systems/CollisionSystem.cpp
@@ -43,35 +43,7 @@ namespace FishGame
     // --- Helper methods ----------------------------------------------------
     void CollisionSystem::handlePowerUpCollision(Player& player, PowerUp& powerUp)
     {
-        switch (powerUp.getPowerUpType())
-        {
-        case PowerUpType::ScoreDoubler:
-            m_powerUps.activatePowerUp(powerUp.getPowerUpType(), powerUp.getDuration());
-            createParticle(powerUp.getPosition(), Constants::SCORE_DOUBLER_COLOR);
-            break;
-        case PowerUpType::FrenzyStarter:
-            m_frenzySystem.forceFrenzy();
-            createParticle(powerUp.getPosition(), Constants::FRENZY_STARTER_COLOR);
-            break;
-        case PowerUpType::SpeedBoost:
-            m_powerUps.activatePowerUp(powerUp.getPowerUpType(), powerUp.getDuration());
-            player.applySpeedBoost(m_powerUps.getSpeedMultiplier(), powerUp.getDuration());
-            m_sounds.play(SoundEffectID::SpeedStart);
-            createParticle(powerUp.getPosition(), Constants::SPEED_BOOST_COLOR);
-            break;
-        case PowerUpType::Freeze:
-            m_powerUps.activatePowerUp(powerUp.getPowerUpType(), powerUp.getDuration());
-            m_applyFreeze();
-            createParticle(powerUp.getPosition(), sf::Color::Cyan, 20);
-            break;
-        case PowerUpType::ExtraLife:
-            m_playerLives++;
-            m_sounds.play(SoundEffectID::LifePowerup);
-            createParticle(powerUp.getPosition(), sf::Color::Green, 15);
-            break;
-        case PowerUpType::AddTime:
-            break;
-        }
+        powerUp.applyEffect(player, *this);
     }
 
     void CollisionSystem::handleOysterCollision(Player& player, PermanentOyster* oyster)


### PR DESCRIPTION
## Summary
- add abstract `applyEffect` method to `PowerUp`
- implement effect handling in all power-up classes
- refactor `CollisionSystem::handlePowerUpCollision` to use `applyEffect`

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_687610cbf25083338b92f6393fc2d131