### PR TITLE
Refactor player status

### DIFF
--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -17,9 +17,11 @@ namespace FishGame
     class PlayerInput;
     class PlayerGrowth;
     class PlayerVisual;
+    class PlayerStatus;
 
     class Player : public Entity
     {
+        friend class PlayerStatus;
     public:
         struct VisualEffect
         {
@@ -72,8 +74,8 @@ namespace FishGame
         void takeDamage();
         void die();
         void respawn();
-        bool isInvulnerable() const { return m_invulnerabilityTimer > sf::Time::Zero; }
-        bool hasRecentlyTakenDamage() const { return m_damageCooldown > sf::Time::Zero; }
+        bool isInvulnerable() const;
+        bool hasRecentlyTakenDamage() const;
 
         // Power-up effects
         void applySpeedBoost(float multiplier, sf::Time duration);
@@ -129,7 +131,7 @@ namespace FishGame
         const std::string& getCurrentAnimation() const { return m_currentAnimation; }
         void setCurrentAnimation(const std::string& anim) { m_currentAnimation = anim; }
         bool isFacingRight() const { return m_facingRight; }
-        sf::Time getInvulnerabilityTimer() const { return m_invulnerabilityTimer; }
+        sf::Time getInvulnerabilityTimer() const;
 
         static constexpr float baseSpeed() { return m_baseSpeed; }
         static constexpr float baseRadius() { return m_baseRadius; }
@@ -155,7 +157,6 @@ namespace FishGame
 
     private:
         void constrainToWindow();
-        void updateInvulnerability(sf::Time deltaTime);
 
     private:
         int m_score;
@@ -182,11 +183,8 @@ namespace FishGame
         SpriteManager* m_spriteManager;
         SoundPlayer* m_soundPlayer{ nullptr };
 
-        // Invulnerability and damage
-        sf::Time m_invulnerabilityTimer;
-        sf::Time m_damageCooldown;
-        static const sf::Time m_invulnerabilityDuration;
-        static const sf::Time m_damageCooldownDuration;
+        // Status handling
+        std::unique_ptr<PlayerStatus> m_status;
 
         // Power-up effects
         float m_speedMultiplier;

--- a/include/Entities/PlayerStatus.h
+++ b/include/Entities/PlayerStatus.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <SFML/System/Time.hpp>
+
+namespace FishGame
+{
+    class Player;
+    class Entity;
+
+    class PlayerStatus
+    {
+    public:
+        explicit PlayerStatus(Player& player);
+
+        void update(sf::Time deltaTime);
+
+        bool canEat(const Entity& other) const;
+        bool attemptEat(Entity& other);
+        bool canTailBite(const Entity& other) const;
+        bool attemptTailBite(Entity& other);
+
+        void takeDamage();
+        void die();
+        void respawn();
+
+        bool isInvulnerable() const { return m_invulnerabilityTimer > sf::Time::Zero; }
+        bool hasRecentlyTakenDamage() const { return m_damageCooldown > sf::Time::Zero; }
+        sf::Time getInvulnerabilityTimer() const { return m_invulnerabilityTimer; }
+
+    private:
+        Player& m_player;
+        sf::Time m_invulnerabilityTimer;
+        sf::Time m_damageCooldown;
+        static const sf::Time m_invulnerabilityDuration;
+        static const sf::Time m_damageCooldownDuration;
+    };
+}

--- a/src/Entities/PlayerStatus.cpp
+++ b/src/Entities/PlayerStatus.cpp
@@ -1,0 +1,207 @@
+#include "PlayerStatus.h"
+#include "Player.h"
+#include "Fish.h"
+#include "CollisionDetector.h"
+#include "FrenzySystem.h"
+#include "IPowerUpManager.h"
+#include "IScoreSystem.h"
+#include "Animator.h"
+#include <cmath>
+
+namespace FishGame {
+
+const sf::Time PlayerStatus::m_invulnerabilityDuration = sf::seconds(2.0f);
+const sf::Time PlayerStatus::m_damageCooldownDuration = sf::seconds(0.5f);
+
+PlayerStatus::PlayerStatus(Player& player)
+    : m_player(player)
+    , m_invulnerabilityTimer(sf::Time::Zero)
+    , m_damageCooldown(sf::Time::Zero)
+{
+}
+
+void PlayerStatus::update(sf::Time deltaTime)
+{
+    if (m_invulnerabilityTimer > sf::Time::Zero) {
+        m_invulnerabilityTimer -= deltaTime;
+        if (m_invulnerabilityTimer < sf::Time::Zero)
+            m_invulnerabilityTimer = sf::Time::Zero;
+    }
+
+    if (m_damageCooldown > sf::Time::Zero)
+        m_damageCooldown -= deltaTime;
+}
+
+bool PlayerStatus::canEat(const Entity& other) const
+{
+    if (m_invulnerabilityTimer > sf::Time::Zero)
+        return false;
+
+    EntityType otherType = other.getType();
+    if (otherType == EntityType::SmallFish ||
+        otherType == EntityType::MediumFish ||
+        otherType == EntityType::LargeFish)
+    {
+        const Fish* fish = dynamic_cast<const Fish*>(&other);
+        if (!fish)
+            return false;
+
+        FishSize playerSize = m_player.getCurrentFishSize();
+        FishSize fishSize = fish->getSize();
+
+        return static_cast<int>(playerSize) >= static_cast<int>(fishSize);
+    }
+
+    return false;
+}
+
+bool PlayerStatus::attemptEat(Entity& other)
+{
+    if (!canEat(other))
+        return false;
+
+    sf::Vector2f mouthOffset(m_player.getRadius(), 0.f);
+    mouthOffset.x = m_player.isFacingRight() ? mouthOffset.x : -mouthOffset.x;
+
+    sf::Vector2f mouthPos = m_player.getPosition() + mouthOffset * 0.8f;
+    float mouthRadius = m_player.getRadius() * 0.5f;
+
+    float distance = CollisionDetector::getDistance(mouthPos, other.getPosition());
+    if (distance > mouthRadius + other.getRadius())
+        return false;
+
+    const Fish* fish = dynamic_cast<const Fish*>(&other);
+    if (fish)
+    {
+        m_player.addPoints(fish->getScorePoints());
+        m_player.grow(fish->getPointValue());
+
+        if (m_player.m_scoreSystem)
+        {
+            m_player.m_scoreSystem->registerHit();
+
+            int frenzyMultiplier = m_player.m_frenzySystem ? m_player.m_frenzySystem->getMultiplier() : 1;
+            float powerUpMultiplier = m_player.m_powerUpManager ? m_player.m_powerUpManager->getScoreMultiplier() : 1.f;
+
+            m_player.m_scoreSystem->addScore(ScoreEventType::FishEaten, fish->getPointValue(),
+                                             other.getPosition(), frenzyMultiplier, powerUpMultiplier);
+            m_player.m_scoreSystem->recordFish(fish->getTextureID());
+        }
+
+        if (m_player.m_frenzySystem)
+        {
+            m_player.m_frenzySystem->registerFishEaten();
+        }
+
+        if (m_player.getAnimator())
+        {
+            std::string eatAnim = m_player.isFacingRight() ? "eatRight" : "eatLeft";
+            m_player.getAnimator()->play(eatAnim);
+            m_player.setCurrentAnimation(eatAnim);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+bool PlayerStatus::canTailBite(const Entity& other) const
+{
+    const Fish* fish = dynamic_cast<const Fish*>(&other);
+    if (!fish)
+        return false;
+
+    int sizeDifference = static_cast<int>(fish->getSize()) - static_cast<int>(m_player.getCurrentFishSize());
+    return sizeDifference >= 2;
+}
+
+bool PlayerStatus::attemptTailBite(Entity& other)
+{
+    if (canTailBite(other) && !hasRecentlyTakenDamage())
+    {
+        sf::Vector2f fishPos = other.getPosition();
+        sf::Vector2f fishVelocity = other.getVelocity();
+
+        sf::Vector2f tailOffset = -fishVelocity;
+        float length = std::sqrt(tailOffset.x * tailOffset.x + tailOffset.y * tailOffset.y);
+        if (length > 0)
+        {
+            tailOffset = (tailOffset / length) * other.getRadius() * 0.8f;
+            sf::Vector2f tailPos = fishPos + tailOffset;
+
+            float dx = m_player.getPosition().x - tailPos.x;
+            float dy = m_player.getPosition().y - tailPos.y;
+            float distance = std::sqrt(dx * dx + dy * dy);
+
+            if (distance < m_player.getRadius() + 10.f)
+            {
+                if (m_player.m_scoreSystem)
+                {
+                    int frenzyMultiplier = m_player.m_frenzySystem ? m_player.m_frenzySystem->getMultiplier() : 1;
+                    float powerUpMultiplier = m_player.m_powerUpManager ? m_player.m_powerUpManager->getScoreMultiplier() : 1.f;
+
+                    m_player.m_scoreSystem->registerTailBite(m_player.getPosition(), frenzyMultiplier, powerUpMultiplier);
+                }
+
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void PlayerStatus::takeDamage()
+{
+    if (m_invulnerabilityTimer > sf::Time::Zero)
+        return;
+
+    m_damageCooldown = m_damageCooldownDuration;
+
+    if (m_player.m_scoreSystem)
+    {
+        m_player.m_scoreSystem->registerMiss();
+    }
+
+    m_player.triggerDamageEffect();
+}
+
+void PlayerStatus::die()
+{
+    m_player.m_isAlive = false;
+    m_player.m_position = {static_cast<float>(m_player.m_windowBounds.x) / 2.f,
+                           static_cast<float>(m_player.m_windowBounds.y) / 2.f};
+    m_player.m_velocity = {0.f, 0.f};
+    m_player.m_targetPosition = m_player.m_position;
+
+    m_invulnerabilityTimer = m_invulnerabilityDuration;
+
+    m_player.m_growthProgress = std::max(0.f, m_player.m_growthProgress - 20.f);
+
+    if (m_player.m_growthMeter)
+    {
+        m_player.m_growthMeter->setPoints(m_player.m_points);
+    }
+
+    m_player.m_eatAnimationScale = 1.f;
+    m_player.m_damageFlashIntensity = 0.f;
+    m_player.m_controlsReversed = false;
+    m_player.m_poisonColorTimer = sf::Time::Zero;
+}
+
+void PlayerStatus::respawn()
+{
+    m_player.m_isAlive = true;
+    m_player.m_position = {static_cast<float>(m_player.m_windowBounds.x) / 2.f,
+                           static_cast<float>(m_player.m_windowBounds.y) / 2.f};
+    m_player.m_velocity = {0.f, 0.f};
+    m_player.m_targetPosition = m_player.m_position;
+    m_invulnerabilityTimer = m_invulnerabilityDuration;
+    m_player.m_controlsReversed = false;
+    m_player.m_poisonColorTimer = sf::Time::Zero;
+    if (m_player.m_soundPlayer)
+        m_player.m_soundPlayer->play(SoundEffectID::PlayerSpawn);
+}
+
+} // namespace FishGame


### PR DESCRIPTION
## Summary
- create `PlayerStatus` to manage health and scoring
- update `Player` to use the new helper
- forward hit detection and damage calls to `PlayerStatus`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_687610e1c7fc83339271661460bf27a0