### PR TITLE
Remove FPS text from HUD

### DIFF
--- a/include/Systems/HUDSystem.h
+++ b/include/Systems/HUDSystem.h
@@ -35,7 +35,6 @@ namespace FishGame
         sf::Text m_levelText;
         sf::Text m_chainText;
         sf::Text m_powerUpText;
-        sf::Text m_fpsText;
         sf::Text m_effectsText;
         sf::Text m_messageText;
 

--- a/src/Systems/HUDSystem.cpp
+++ b/src/Systems/HUDSystem.cpp
@@ -17,8 +17,6 @@ namespace FishGame
             sf::Vector2f(Constants::HUD_MARGIN, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING * 3));
         initText(m_powerUpText, Constants::HUD_SMALL_FONT_SIZE,
             sf::Vector2f(windowSize.x - Constants::POWERUP_TEXT_X_OFFSET, Constants::HUD_MARGIN + Constants::HUD_LINE_SPACING));
-        initText(m_fpsText, Constants::HUD_FONT_SIZE,
-            sf::Vector2f(windowSize.x - Constants::FPS_TEXT_X_OFFSET, Constants::HUD_MARGIN));
         initText(m_effectsText, 18,
             sf::Vector2f(Constants::HUD_EFFECTS_TEXT_X,
                 windowSize.y - Constants::HUD_EFFECTS_TEXT_Y_OFFSET), sf::Color::Yellow);
@@ -82,10 +80,6 @@ namespace FishGame
         }
 
         stream.str(""); stream.clear();
-        stream << std::fixed << std::setprecision(1) << "FPS: " << fps;
-        m_fpsText.setString(stream.str());
-
-        stream.str(""); stream.clear();
         if (frozen)
             stream << "FREEZE ACTIVE: " << std::fixed << std::setprecision(1)
                 << freezeTime.asSeconds() << "s\n";
@@ -126,7 +120,6 @@ namespace FishGame
         target.draw(m_levelText, states);
         target.draw(m_chainText, states);
         target.draw(m_powerUpText, states);
-        target.draw(m_fpsText, states);
         target.draw(m_effectsText, states);
         if (!m_messageText.getString().isEmpty())
             target.draw(m_messageText, states);


### PR DESCRIPTION
## Summary
- remove initialization, update, and drawing of FPS text
- drop `m_fpsText` member from `HUDSystem`

## Testing
- `cmake --preset x64-Debug` *(fails: Could not find package configuration file provided by "SFML")*

------
https://chatgpt.com/codex/tasks/task_e_68761476a96c8333a13cc6522c36d14f