### PR TITLE
Reduce warnings

### DIFF
--- a/include/Entities/Fish.h
+++ b/include/Entities/Fish.h
@@ -28,6 +28,7 @@ namespace FishGame
     {
         friend class CollisionSystem;
     public:
+        using ICollidable::onCollideWith;
         Fish(FishSize size, float speed, int currentLevel);
         virtual ~Fish() = default;
 

--- a/include/Entities/Hazard.h
+++ b/include/Entities/Hazard.h
@@ -20,6 +20,7 @@ namespace FishGame
     {
         friend class CollisionSystem;
     public:
+        using ICollidable::onCollideWith;
         Hazard(HazardType type, float damageAmount);
         virtual ~Hazard() = default;
 

--- a/include/Entities/ICollidable.h
+++ b/include/Entities/ICollidable.h
@@ -15,7 +15,7 @@ namespace FishGame {
         virtual void onCollide(Player& player, CollisionSystem& system) = 0;
 
         // Generic double dispatch entry point
-        virtual void onCollideWith(Entity& entity, CollisionSystem& system) {}
+        virtual void onCollideWith(Entity&, CollisionSystem&) {}
 
         // Overloads for specific entity types
         virtual void onCollideWith(Player& player, CollisionSystem& system)

--- a/include/Entities/Player.h
+++ b/include/Entities/Player.h
@@ -23,6 +23,7 @@ namespace FishGame
     {
         friend class PlayerStatus;
     public:
+        using ICollidable::onCollideWith;
         struct VisualEffect
         {
             float scale = 1.f;

--- a/src/Entities/Angelfish.cpp
+++ b/src/Entities/Angelfish.cpp
@@ -72,7 +72,7 @@ namespace FishGame
         std::for_each(std::execution::unseq, finIdx.begin(), finIdx.end(),
             [this](size_t i)
             {
-                float finAngle = (m_colorShift + i * 120.0f) * 3.14159f / 180.0f;
+                float finAngle = (m_colorShift + static_cast<float>(i) * 120.0f) * 3.14159f / 180.0f;
                 float finRadius = 20.0f + (m_isEvading ? 10.0f * std::sin(m_colorShift * 5.0f) : 0.0f);
 
                 sf::Vector2f finPos(

--- a/src/Entities/BonusItem.cpp
+++ b/src/Entities/BonusItem.cpp
@@ -144,7 +144,7 @@ namespace FishGame
         }
     }
 
-    void BonusItem::onCollide(Player& player, CollisionSystem& system)
+    void BonusItem::onCollide(Player& /*player*/, CollisionSystem& system)
     {
         onCollect();
 

--- a/src/Entities/ExtendedPowerUps.cpp
+++ b/src/Entities/ExtendedPowerUps.cpp
@@ -82,7 +82,7 @@ void FreezePowerUp::onCollect()
     destroy();
 }
 
-void FreezePowerUp::applyEffect(Player& player, CollisionSystem& system)
+void FreezePowerUp::applyEffect(Player& /*player*/, CollisionSystem& system)
 {
     system.m_powerUps.activatePowerUp(getPowerUpType(), getDuration());
     system.m_applyFreeze();
@@ -147,7 +147,7 @@ void ExtraLifePowerUp::onCollect()
     destroy();
 }
 
-void ExtraLifePowerUp::applyEffect(Player& player, CollisionSystem& system)
+void ExtraLifePowerUp::applyEffect(Player& /*player*/, CollisionSystem& system)
 {
     system.m_playerLives++;
     system.m_sounds.play(SoundEffectID::LifePowerup);
@@ -296,7 +296,7 @@ void AddTimePowerUp::onCollect()
     destroy();
 }
 
-void AddTimePowerUp::applyEffect(Player& player, CollisionSystem& system)
+void AddTimePowerUp::applyEffect(Player& /*player*/, CollisionSystem& /*system*/)
 {
     // No effect defined yet
 }

--- a/src/Entities/Hazard.cpp
+++ b/src/Entities/Hazard.cpp
@@ -297,8 +297,8 @@ namespace FishGame
         std::for_each(std::execution::unseq, tentIdx.begin(), tentIdx.end(),
             [this](size_t i)
             {
-                float angle = (360.0f / m_tentacleCount) * i * Constants::DEG_TO_RAD;
-                float wave = std::sin(m_tentacleWave + i * 0.5f) * 10.0f;
+                float angle = (360.0f / m_tentacleCount) * static_cast<float>(i) * Constants::DEG_TO_RAD;
+                float wave = std::sin(m_tentacleWave + static_cast<float>(i) * 0.5f) * 10.0f;
 
                 sf::Vector2f tentaclePos(
                     m_position.x + std::cos(angle) * 15.0f,

--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -40,6 +40,7 @@ namespace FishGame
         , m_scoreSystem(nullptr)
         , m_spriteManager(nullptr)
         , m_soundPlayer(nullptr)
+        , m_status(std::make_unique<PlayerStatus>(*this))
         , m_speedMultiplier(1.0f)
         , m_speedBoostTimer(sf::Time::Zero)
         , m_windowBounds(Constants::WINDOW_WIDTH, Constants::WINDOW_HEIGHT)
@@ -51,11 +52,10 @@ namespace FishGame
         , m_damageFlashIntensity(0.0f)
         , m_animator(nullptr)
         , m_currentAnimation()
-        , m_facingRight(false)
         , m_input(std::make_unique<PlayerInput>(*this))
         , m_growth(std::make_unique<PlayerGrowth>(*this))
         , m_visual(std::make_unique<PlayerVisual>(*this))
-        , m_status(std::make_unique<PlayerStatus>(*this))
+        , m_facingRight(false)
     {
         m_radius = m_baseRadius;
 

--- a/src/Entities/PlayerStatus.cpp
+++ b/src/Entities/PlayerStatus.cpp
@@ -5,6 +5,7 @@
 #include "FrenzySystem.h"
 #include "IPowerUpManager.h"
 #include "IScoreSystem.h"
+#include "ScoreSystem.h"
 #include "Animator.h"
 #include <cmath>
 

--- a/src/Entities/PoisonFish.cpp
+++ b/src/Entities/PoisonFish.cpp
@@ -69,8 +69,8 @@ namespace FishGame
         std::for_each(std::execution::unseq, bubbleIdx.begin(), bubbleIdx.end(),
             [this](size_t i)
             {
-                float angle = (60.0f * i + m_wobbleAnimation * 30.0f) * Constants::DEG_TO_RAD;
-                float radius = 18.0f + 3.0f * std::sin(m_wobbleAnimation + i);
+                float angle = (60.0f * static_cast<float>(i) + m_wobbleAnimation * 30.0f) * Constants::DEG_TO_RAD;
+                float radius = 18.0f + 3.0f * std::sin(m_wobbleAnimation + static_cast<float>(i));
 
                 sf::Vector2f bubblePos(
                     m_position.x + std::cos(angle) * radius,
@@ -79,7 +79,7 @@ namespace FishGame
                 m_poisonBubbles[i].setPosition(bubblePos);
 
                 // Pulsing effect for bubbles
-                float scale = 1.0f + 0.2f * std::sin(m_wobbleAnimation * 2.0f + i);
+                float scale = 1.0f + 0.2f * std::sin(m_wobbleAnimation * 2.0f + static_cast<float>(i));
                 m_poisonBubbles[i].setScale(scale, scale);
             });
     }

--- a/src/Entities/PowerUp.cpp
+++ b/src/Entities/PowerUp.cpp
@@ -94,7 +94,7 @@ void ScoreDoublerPowerUp::onCollect()
     destroy();
 }
 
-void ScoreDoublerPowerUp::applyEffect(Player& player, CollisionSystem& system)
+void ScoreDoublerPowerUp::applyEffect(Player& /*player*/, CollisionSystem& system)
 {
     system.m_powerUps.activatePowerUp(getPowerUpType(), getDuration());
     system.createParticle(getPosition(), Constants::SCORE_DOUBLER_COLOR);
@@ -174,7 +174,7 @@ void FrenzyStarterPowerUp::onCollect()
     destroy();
 }
 
-void FrenzyStarterPowerUp::applyEffect(Player& player, CollisionSystem& system)
+void FrenzyStarterPowerUp::applyEffect(Player& /*player*/, CollisionSystem& system)
 {
     system.m_frenzySystem.forceFrenzy();
     system.createParticle(getPosition(), Constants::FRENZY_STARTER_COLOR);

--- a/src/Entities/Pufferfish.cpp
+++ b/src/Entities/Pufferfish.cpp
@@ -65,7 +65,7 @@ namespace FishGame
             std::for_each(std::execution::unseq, spikeIdx.begin(), spikeIdx.end(),
                 [this](size_t i)
                 {
-                    float angle = (360.0f / m_spikeCount) * i * Constants::DEG_TO_RAD;
+                    float angle = (360.0f / m_spikeCount) * static_cast<float>(i) * Constants::DEG_TO_RAD;
                     float spikeRadius = m_radius + (m_inflationLevel * 10.0f);
 
                     sf::Vector2f spikePos(
@@ -112,7 +112,7 @@ namespace FishGame
         std::for_each(std::execution::unseq, spikeIdx2.begin(), spikeIdx2.end(),
             [this](size_t i)
             {
-                float angle = (360.0f / m_spikeCount) * i * Constants::DEG_TO_RAD;
+                float angle = (360.0f / m_spikeCount) * static_cast<float>(i) * Constants::DEG_TO_RAD;
                 float spikeRadius = m_radius + (m_inflationLevel * 10.0f);
 
                 sf::Vector2f spikePos(

--- a/src/States/PlayState.cpp
+++ b/src/States/PlayState.cpp
@@ -346,6 +346,9 @@ void PlayState::updateGameState(sf::Time deltaTime)
             getGame().getSoundPlayer().play(SoundEffectID::LifePowerup);
             createParticleEffect(powerUp.getPosition(), sf::Color::Green, 15);
             break;
+        case PowerUpType::AddTime:
+            // No immediate effect handled here
+            break;
         }
     }
 

--- a/src/States/StageIntroState.cpp
+++ b/src/States/StageIntroState.cpp
@@ -202,7 +202,7 @@ void StageIntroState::handleEvent(const sf::Event &event) {
     }
 }
 
-bool StageIntroState::update(sf::Time deltaTime) {
+bool StageIntroState::update(sf::Time /*deltaTime*/) {
   processDeferredActions();
   return false;
 }

--- a/src/Systems/HUDSystem.cpp
+++ b/src/Systems/HUDSystem.cpp
@@ -33,7 +33,7 @@ namespace FishGame
         bool frozen, sf::Time freezeTime,
         bool reversed, sf::Time reverseTime,
         bool stunned, sf::Time stunTime,
-        float fps)
+        float /*fps*/)
     {
         std::ostringstream stream;
         stream << "Score: " << score;


### PR DESCRIPTION
## Summary
- silence unused parameter warnings
- clarify overloaded functions with `using` directives
- fix initializer list ordering
- add missing include for score events
- cast indices to avoid -Wconversion warnings

## Testing
- `cmake ..`
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_6876192207348333badac4e0f6596245