### PR TITLE
Fix OpenGL context errors in Play state

### DIFF
--- a/src/Managers/SpriteManager.cpp
+++ b/src/Managers/SpriteManager.cpp
@@ -79,10 +79,9 @@ void SpriteManager::loadTextures(const std::string& assetPath)
 {
         m_textureHolder.reserve(s_textureFiles.size());
 
-        // Load textures sequentially to avoid OpenGL context conflicts
+        // Load textures sequentially using the existing window context
         for (const auto& [id, filename] : s_textureFiles)
         {
-            sf::Context context;
             std::string fullPath = assetPath.empty() ? filename
                 : assetPath + "/" + filename;
             auto tex = std::make_unique<sf::Texture>();

--- a/src/States/BonusStageState.cpp
+++ b/src/States/BonusStageState.cpp
@@ -206,30 +206,30 @@ namespace FishGame
             }
         }
 
-        // Update entities
-        std::for_each(std::execution::par_unseq, m_entities.begin(), m_entities.end(),
-            [deltaTime, this](auto& entity) {
-                entity->update(deltaTime);
+        // Update entities sequentially to keep rendering thread-safe
+        for (auto& entity : m_entities)
+        {
+            entity->update(deltaTime);
 
-                // Apply ocean currents to fish
-                if (Fish* fish = dynamic_cast<Fish*>(entity.get()))
-                {
-                    sf::Vector2f force = m_environment->getOceanCurrentForce(entity->getPosition());
-                    entity->setVelocity(entity->getVelocity() + force * deltaTime.asSeconds() * 0.5f);
-                }
-            });
+            // Apply ocean currents to fish
+            if (Fish* fish = dynamic_cast<Fish*>(entity.get()))
+            {
+                sf::Vector2f force = m_environment->getOceanCurrentForce(entity->getPosition());
+                entity->setVelocity(entity->getVelocity() + force * deltaTime.asSeconds() * 0.5f);
+            }
+        }
 
-        // Update bonus items
-        std::for_each(std::execution::par_unseq, m_bonusItems.begin(), m_bonusItems.end(),
-            [deltaTime](auto& item) {
-                item->update(deltaTime);
-            });
+        // Update bonus items sequentially
+        for (auto& item : m_bonusItems)
+        {
+            item->update(deltaTime);
+        }
 
-        // Update hazards
-        std::for_each(std::execution::par_unseq, m_hazards.begin(), m_hazards.end(),
-            [deltaTime](auto& hazard) {
-                hazard->update(deltaTime);
-            });
+        // Update hazards sequentially
+        for (auto& hazard : m_hazards)
+        {
+            hazard->update(deltaTime);
+        }
 
         // Handle collisions with bonus items
         std::for_each(m_bonusItems.begin(), m_bonusItems.end(),

--- a/src/Systems/ParticleSystem.cpp
+++ b/src/Systems/ParticleSystem.cpp
@@ -16,16 +16,15 @@ namespace FishGame
 
     void ParticleSystem::update(sf::Time dt)
     {
-        std::for_each(std::execution::par_unseq,
-            m_particles.begin(), m_particles.end(),
-            [dt](Particle& p) {
-                p.lifetime -= dt;
-                p.shape.move(p.velocity * dt.asSeconds());
-                p.alpha = std::max(0.f, p.alpha - Constants::PARTICLE_FADE_RATE * dt.asSeconds());
-                sf::Color c = p.shape.getFillColor();
-                c.a = static_cast<sf::Uint8>(p.alpha);
-                p.shape.setFillColor(c);
-            });
+        for (auto& p : m_particles)
+        {
+            p.lifetime -= dt;
+            p.shape.move(p.velocity * dt.asSeconds());
+            p.alpha = std::max(0.f, p.alpha - Constants::PARTICLE_FADE_RATE * dt.asSeconds());
+            sf::Color c = p.shape.getFillColor();
+            c.a = static_cast<sf::Uint8>(p.alpha);
+            p.shape.setFillColor(c);
+        }
         m_particles.erase(std::remove_if(m_particles.begin(), m_particles.end(),
             [](const Particle& p){ return p.lifetime <= sf::Time::Zero; }), m_particles.end());
     }


### PR DESCRIPTION
## Summary
- remove usage of `std::execution::par_unseq` when updating/drawing SFML objects
- use sequential loops in `ParticleSystem`, `EnvironmentSystem`, and `BonusStageState`

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*
- `make -C build -j$(nproc)` *(not run: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687642c59048833399de671ce8499d19